### PR TITLE
Revert "Add CPU Time since last sample data on JFR events (#16)"

### DIFF
--- a/src/event.h
+++ b/src/event.h
@@ -31,9 +31,8 @@ class Event {
 class ExecutionEvent : public Event {
   public:
     ThreadState _thread_state;
-    u64 _cpu_time;
 
-    ExecutionEvent() : _thread_state(THREAD_RUNNING), _cpu_time(0) {
+    ExecutionEvent() : _thread_state(THREAD_RUNNING) {
     }
 };
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1131,7 +1131,6 @@ class Recording {
         buf->putVar32(tid);
         buf->putVar32(call_trace_id);
         buf->putVar32(event->_thread_state);
-        buf->putVar64(event->_cpu_time);
         buf->put8(start, buf->offset() - start);
     }
 

--- a/src/itimer.h
+++ b/src/itimer.h
@@ -18,13 +18,11 @@
 #define _ITIMER_H
 
 #include <signal.h>
-#include "arch.h"
 #include "engine.h"
 
 
 class ITimer : public Engine {
   private:
-    static volatile u64 _cputime_epoch;
     static long _interval;
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -90,8 +90,7 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
                 << field("sampledThread", T_THREAD, "Thread", F_CPOOL)
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
-                << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
-                << field("cpuTime", T_LONG, "CPU Time since last sample", F_DURATION_TICKS))
+                << field("state", T_THREAD_STATE, "Thread State", F_CPOOL))
 
             << (type("jdk.ObjectAllocationInNewTLAB", T_ALLOC_IN_NEW_TLAB, "Allocation in new TLAB")
                 << category("Java Application")

--- a/src/os.h
+++ b/src/os.h
@@ -62,7 +62,6 @@ class OS {
     static const size_t page_size;
     static const size_t page_mask;
 
-    static u64 cputime();
     static u64 nanotime();
     static u64 micros();
     static u64 processStartTime();

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -121,12 +121,6 @@ JitWriteProtection::~JitWriteProtection() {
 const size_t OS::page_size = sysconf(_SC_PAGESIZE);
 const size_t OS::page_mask = OS::page_size - 1;
 
-u64 OS::cputime() {
-    struct timespec ts;
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
-    return (u64)ts.tv_sec * 1000000000 + ts.tv_nsec;
-}
-
 u64 OS::nanotime() {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -117,12 +117,11 @@ const size_t OS::page_mask = OS::page_size - 1;
 
 static mach_timebase_info_data_t timebase = {0, 0};
 
-u64 OS::cputime() {
-    return clock_gettime_nsec_np(CLOCK_THREAD_CPUTIME_ID);
-}
-
 u64 OS::nanotime() {
-    return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+    if (timebase.denom == 0) {
+        mach_timebase_info(&timebase);
+    }
+    return (u64)mach_absolute_time() * timebase.numer / timebase.denom;
 }
 
 u64 OS::micros() {

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -18,7 +18,6 @@
 #define _PERFEVENTS_H
 
 #include <signal.h>
-#include "arch.h"
 #include "engine.h"
 
 
@@ -30,7 +29,6 @@ class PerfEvents : public Engine {
     static int _max_events;
     static PerfEvent* _events;
     static PerfEventType* _event_type;
-    static volatile u64 _cputime_epoch;
     static long _interval;
     static Ring _ring;
     static CStack _cstack;

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -499,7 +499,6 @@ class PerfEvent : public SpinLock {
 int PerfEvents::_max_events = 0;
 PerfEvent* PerfEvents::_events = NULL;
 PerfEventType* PerfEvents::_event_type = NULL;
-volatile u64 PerfEvents::_cputime_epoch = 0;
 long PerfEvents::_interval;
 Ring PerfEvents::_ring;
 CStack PerfEvents::_cstack;
@@ -622,9 +621,6 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
 
     if (_enabled) {
-        static __thread u64 cputime_epoch;
-        static __thread u64 cputime_prev;
-
         u64 counter;
         switch (_event_type->counter_arg) {
             case 1: counter = StackFrame(ucontext).arg0(); break;
@@ -638,11 +634,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         }
 
         ExecutionEvent event;
-        event._cpu_time = _cputime_epoch == cputime_epoch ? OS::cputime() - cputime_prev : 0;
         Profiler::instance()->recordSample(ucontext, counter, 0, &event);
-
-        cputime_epoch = _cputime_epoch;
-        cputime_prev += event._cpu_time;
     } else {
         resetBuffer(OS::threadId());
     }
@@ -729,8 +721,6 @@ Error PerfEvents::start(Arguments& args) {
     }
     _interval = args._interval ? args._interval : _event_type->default_interval;
 
-    _cputime_epoch++;
-
     _ring = args._ring;
     if (_ring != RING_USER && !Symbols::haveKernelSymbols()) {
         Log::warn("Kernel symbols are unavailable due to restrictions. Try\n"
@@ -746,7 +736,6 @@ Error PerfEvents::start(Arguments& args) {
         _events = (PerfEvent*)calloc(max_events, sizeof(PerfEvent));
         _max_events = max_events;
     }
-
 
     OS::installSignalHandler(SIGPROF, signalHandler);
 

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -32,7 +32,7 @@ const int THREADS_PER_TICK = 8;
 // Smaller intervals are practically unusable due to large overhead.
 const long MIN_INTERVAL = 100000;
 
-volatile u64 WallClock::_cputime_epoch = 0;
+
 long WallClock::_interval;
 bool WallClock::_sample_idle_threads;
 
@@ -58,16 +58,9 @@ ThreadState WallClock::getThreadState(void* ucontext) {
 }
 
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
-    static __thread u64 cputime_epoch;
-    static __thread u64 cputime_prev;
-
     ExecutionEvent event;
     event._thread_state = _sample_idle_threads ? getThreadState(ucontext) : THREAD_RUNNING;
-    event._cpu_time = _cputime_epoch == cputime_epoch ? OS::cputime() - cputime_prev : 0;
     Profiler::instance()->recordSample(ucontext, _interval, 0, &event);
-
-    cputime_epoch = _cputime_epoch;
-    cputime_prev += event._cpu_time;
 }
 
 long WallClock::adjustInterval(long interval, int thread_count) {
@@ -86,7 +79,6 @@ Error WallClock::start(Arguments& args) {
 
     // Increase default interval for wall clock mode due to larger number of sampled threads
     _interval = args._interval ? args._interval : (_sample_idle_threads ? DEFAULT_INTERVAL * 5 : DEFAULT_INTERVAL);
-    _cputime_epoch++;
 
     OS::installSignalHandler(SIGVTALRM, signalHandler);
 

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -26,7 +26,6 @@
 
 class WallClock : public Engine {
   private:
-    static volatile u64 _cputime_epoch;
     static long _interval;
     static bool _sample_idle_threads;
 


### PR DESCRIPTION
Need to revert #16 as it leads to deadlocks in the signal handler