### PR TITLE
passive filtering

### DIFF
--- a/src/allocTracer.cpp
+++ b/src/allocTracer.cpp
@@ -69,9 +69,6 @@ void AllocTracer::recordAllocation(void* ucontext, int event_type, uintptr_t rkl
                                    uintptr_t total_size, uintptr_t instance_size) {
     int tid = ProfiledThread::currentTid();
     Context ctx = Contexts::get(tid);
-    if (!Contexts::filter(ctx, event_type)) {
-        return;
-    }
 
     AllocEvent event;
     event._total_size = total_size;

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -203,9 +203,6 @@ Error Arguments::parse(const char* args) {
                     msg = "cpu must be >= 0";
                 }
 
-            CASE("cpufilter")
-                _cpu_filtering = true;
-
             CASE("cputpt")
                 if (value == NULL || (_cpu_threads_per_tick = atoi(value)) <= 0) {
                     msg = "cputpt must be > 0";
@@ -225,9 +222,6 @@ Error Arguments::parse(const char* args) {
                 if (_wall < 0) {
                     msg = "wall must be >= 0";
                 }
-
-            CASE("wallfilter")
-                _wall_filtering = true;
 
             CASE("walltpt")
                 if (value == NULL || (_wall_threads_per_tick = atoi(value)) <= 0) {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -144,10 +144,8 @@ class Arguments {
     int _timeout;
     long _interval;
     long _cpu;
-    bool _cpu_filtering;
     int _cpu_threads_per_tick;
     long _wall;
-    bool _wall_filtering;
     bool _wall_collapsing;
     int _wall_threads_per_tick;
     long _alloc;
@@ -196,10 +194,8 @@ class Arguments {
         _timeout(0),
         _interval(0),
         _cpu(-1),
-        _cpu_filtering(false),
         _cpu_threads_per_tick(DEFAULT_CPU_THREADS_PER_TICK),
         _wall(-1),
-        _wall_filtering(false),
         _wall_collapsing(false),
         _wall_threads_per_tick(DEFAULT_WALL_THREADS_PER_TICK),
         _alloc(-1),

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,29 +21,8 @@
 int Contexts::_contexts_size = -1;
 Context* Contexts::_contexts = NULL;
 
-bool Contexts::_wall_filtering = true;
-bool Contexts::_cpu_filtering = true;
-
 Context Contexts::get(int tid) {
     return _contexts[tid];
-}
-
-bool Contexts::filter(Context ctx, int event_type) {
-    switch (event_type) {
-    case BCI_WALL:
-        return !_wall_filtering || (ctx.valid == 1 && ctx.spanId != 0);
-    case BCI_CPU:
-        return !_cpu_filtering || (ctx.valid == 1 && ctx.spanId != 0);
-    default:
-        // no filtering based on context
-        return true;
-    }
-}
-
-bool Contexts::filter(int tid, int event_type) {
-    // the thread should be suspended, so _contexts[tid] shouldn't change
-    Context context = _contexts[tid];
-    return filter(context, event_type);
 }
 
 void Contexts::initialize() {

--- a/src/context.h
+++ b/src/context.h
@@ -45,8 +45,6 @@ class Contexts {
   private:
     static int _contexts_size;
     static Context* _contexts;
-    static bool _wall_filtering;
-    static bool _cpu_filtering;
 
   public:
     static void initialize();
@@ -58,14 +56,6 @@ class Contexts {
     static bool filter(Context ctx, int event_type);
     // not to be called except to share with Java callers as a DirectByteBuffer
     static ContextStorage getStorage();
-
-
-    static void setWallFiltering(bool wall_filtering) {
-        _wall_filtering = wall_filtering;
-    }
-    static void setCpuFiltering(bool cpu_filtering) {
-        _cpu_filtering = cpu_filtering;
-    }
 };
 
 #endif /* _CONTEXT_H */

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -40,9 +40,6 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         tid = OS::threadId();
     }
     Context ctx = Contexts::get(tid);
-    if (!Contexts::filter(ctx, BCI_CPU)) {
-        return;
-    }
 
     ExecutionEvent event;
     event._context = ctx;

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -191,9 +191,6 @@ void LockTracer::recordContendedLock(int event_type, u64 start_time, u64 end_tim
                                      const char* lock_name, jobject lock, jlong timeout) {
     int tid = ProfiledThread::currentTid();
     Context ctx = Contexts::get(tid);
-    if (!Contexts::filter(ctx, event_type)) {
-        return;
-    }
 
     LockEvent event;
     event._start_time = start_time;

--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -35,9 +35,6 @@ void ObjectSampler::SampledObjectAlloc(jvmtiEnv* jvmti, JNIEnv* jni, jthread thr
 void ObjectSampler::recordAllocation(jvmtiEnv* jvmti, int event_type, jclass object_klass, jlong size) {
     int tid = ProfiledThread::currentTid();
     Context ctx = Contexts::get(tid);
-    if (!Contexts::filter(ctx, event_type)) {
-        return;
-    }
 
     AllocEvent event;
     event._total_size = size > _interval ? size : _interval;

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -711,9 +711,6 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     int tid = current != NULL ? current->tid() : OS::threadId();
     if (_enabled) {
         Context ctx = Contexts::get(tid);
-        if (!Contexts::filter(ctx, BCI_CPU)) {
-            return;
-        }
 
         u64 counter = readCounter(siginfo, ucontext);
         ExecutionEvent event;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -589,10 +589,6 @@ void Profiler::fillFrameTypes(ASGCT_CallFrame* frames, int num_frames, NMethod* 
 void Profiler::recordExternalSample(u64 counter, int tid, jvmtiFrameInfo *jvmti_frames, jint num_jvmti_frames, bool truncated, jint event_type, Event* event) {
     atomicInc(_total_samples);
 
-    if (!Contexts::filter(event->_context, event_type)) {
-        return;
-    }
-
     u32 lock_index = getLockIndex(tid);
     if (!_locks[lock_index].tryLock() &&
         !_locks[lock_index = (lock_index + 1) % CONCURRENCY_LEVEL].tryLock() &&
@@ -701,10 +697,6 @@ void Profiler::recordSample(void* ucontext, u64 counter, int tid, jint event_typ
 
 void Profiler::recordExternalSample(u64 counter, int tid, int num_frames, ASGCT_CallFrame* frames, bool truncated, jint event_type, Event* event) {
     atomicInc(_total_samples);
-
-    if (!Contexts::filter(event->_context, event_type)) {
-        return;
-    }
 
     if (_add_thread_frame) {
         num_frames += makeFrame(frames + num_frames, BCI_THREAD_ID, tid);
@@ -1069,8 +1061,6 @@ Error Profiler::start(Arguments& args, bool reset) {
         return Error("Branch stack is supported only with PMU events");
     }
 
-    Contexts::setWallFiltering(args._wall_filtering);
-    Contexts::setCpuFiltering(args._cpu_filtering);
     // Kernel symbols are useful only for perf_events without --all-user
     updateSymbols(_cpu_engine == &perf_events && (args._ring & RING_KERNEL));
 

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -51,7 +51,6 @@ class WallClock : public Engine {
     // suffer from a big profiling overhead. Also, keeping this limit low enough helps
     // to avoid contention on a spin lock inside Profiler::recordSample().
     int _reservoir_size;
-    bool _filtering;
 
     volatile bool _running;
     pthread_t _thread;
@@ -74,7 +73,6 @@ class WallClock : public Engine {
         _collapsing(false),
         _interval(LONG_MAX),
         _reservoir_size(0),
-        _filtering(false),
         _running(false),
         _thread(0) {}
 


### PR DESCRIPTION
This changes the profiler's role in contextual filtering. Now, if a thread gets interrupted, it will record something no matter what. 

It's up to the tracing caller to make sure:
* threads which should have context will be known to the thread filter, which can be used to avoid interrupting threads which don't have context
* threads which should have context do have context