### PR TITLE
Context consistency check

### DIFF
--- a/src/allocTracer.cpp
+++ b/src/allocTracer.cpp
@@ -68,7 +68,7 @@ void AllocTracer::trapHandler(int signo, siginfo_t* siginfo, void* ucontext) {
 void AllocTracer::recordAllocation(void* ucontext, int event_type, uintptr_t rklass,
                                    uintptr_t total_size, uintptr_t instance_size) {
     int tid = ProfiledThread::currentTid();
-    Context& ctx = Contexts::get(tid);
+    const Context& ctx = Contexts::get(tid);
 
     AllocEvent event;
     event._total_size = total_size;

--- a/src/allocTracer.cpp
+++ b/src/allocTracer.cpp
@@ -68,7 +68,7 @@ void AllocTracer::trapHandler(int signo, siginfo_t* siginfo, void* ucontext) {
 void AllocTracer::recordAllocation(void* ucontext, int event_type, uintptr_t rklass,
                                    uintptr_t total_size, uintptr_t instance_size) {
     int tid = ProfiledThread::currentTid();
-    Context ctx = Contexts::get(tid);
+    Context& ctx = Contexts::get(tid);
 
     AllocEvent event;
     event._total_size = total_size;

--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -227,10 +227,9 @@ public class AsyncProfiler {
         }
         int tid = TID.get();
         int index = tid * CONTEXT_SIZE;
-        contextStorage.putLong(index, 0); // mark invalid
-        contextStorage.putLong(index + 8, spanId);
-        contextStorage.putLong(index + 16, rootSpanId);
-        contextStorage.putLong(index, 1); // mark valid
+        contextStorage.putLong(index, spanId);
+        contextStorage.putLong(index + 8, rootSpanId);
+        contextStorage.putLong(index + 16, spanId ^ rootSpanId);
     }
 
     /**

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,8 +21,12 @@
 int Contexts::_contexts_size = -1;
 Context* Contexts::_contexts = NULL;
 
-Context Contexts::get(int tid) {
+Context& Contexts::get(int tid) {
     return _contexts[tid];
+}
+
+bool Contexts::isValid(Context &context) {
+    return (context.spanId ^ context.rootSpanId) == context.checksum;
 }
 
 void Contexts::initialize() {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,11 +21,11 @@
 int Contexts::_contexts_size = -1;
 Context* Contexts::_contexts = NULL;
 
-Context& Contexts::get(int tid) {
+const Context& Contexts::get(int tid) {
     return _contexts[tid];
 }
 
-bool Contexts::isValid(Context &context) {
+bool Contexts::isValid(const Context &context) {
     return (context.spanId ^ context.rootSpanId) == context.checksum;
 }
 

--- a/src/context.h
+++ b/src/context.h
@@ -22,9 +22,9 @@
 #include "os.h"
 
 typedef struct {
-    u64 valid;
     u64 spanId;
     u64 rootSpanId;
+    u64 checksum;
     u64 pad1;
     u64 pad2;
     u64 pad3;
@@ -48,12 +48,8 @@ class Contexts {
 
   public:
     static void initialize();
-
-    static void set(int tid, Context context);
-    static void clear(int tid);
-    static Context get(int tid);
-    static bool filter(int tid, int event_type);
-    static bool filter(Context ctx, int event_type);
+    static Context& get(int tid);
+    static bool isValid(Context& context);
     // not to be called except to share with Java callers as a DirectByteBuffer
     static ContextStorage getStorage();
 };

--- a/src/context.h
+++ b/src/context.h
@@ -48,8 +48,8 @@ class Contexts {
 
   public:
     static void initialize();
-    static Context& get(int tid);
-    static bool isValid(Context& context);
+    static const Context& get(int tid);
+    static bool isValid(const Context& context);
     // not to be called except to share with Java callers as a DirectByteBuffer
     static ContextStorage getStorage();
 };

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1161,7 +1161,7 @@ class Recording {
     }
 
     void recordExecutionSample(Buffer* buf, int tid, u32 call_trace_id, ExecutionEvent* event) {
-        volatile Context context = event->_context;
+        Context context = event->_context;
 
         int start = buf->skip(1);
         buf->putVar64(T_EXECUTION_SAMPLE);
@@ -1169,7 +1169,7 @@ class Recording {
         buf->putVar64(tid);
         buf->putVar64(call_trace_id);
         buf->putVar64(event->_thread_state);
-        if (context.valid == 1) {
+        if (Contexts::isValid(context)) {
             buf->putVar64(context.spanId);
             buf->putVar64(context.rootSpanId);
         } else {
@@ -1181,7 +1181,7 @@ class Recording {
     }
 
     void recordMethodSample(Buffer* buf, int tid, u32 call_trace_id, ExecutionEvent* event) {
-        volatile Context context = event->_context;
+        Context context = event->_context;
 
         int start = buf->skip(1);
         buf->putVar64(T_METHOD_SAMPLE);
@@ -1189,7 +1189,7 @@ class Recording {
         buf->putVar64(tid);
         buf->putVar64(call_trace_id);
         buf->putVar64(event->_thread_state);
-        if (context.valid == 1) {
+        if (Contexts::isValid(context)) {
             buf->putVar64(context.spanId);
             buf->putVar64(context.rootSpanId);
         } else {
@@ -1201,7 +1201,7 @@ class Recording {
     }
 
     void recordAllocationInNewTLAB(Buffer* buf, int tid, u32 call_trace_id, AllocEvent* event) {
-        volatile Context context = event->_context;
+        Context context = event->_context;
 
         int start = buf->skip(1);
         buf->putVar64(T_ALLOC_IN_NEW_TLAB);
@@ -1211,7 +1211,7 @@ class Recording {
         buf->putVar64(event->_id);
         buf->putVar64(event->_instance_size);
         buf->putVar64(event->_total_size);
-        if (context.valid == 1) {
+        if (Contexts::isValid(context)) {
             buf->putVar64(context.spanId);
             buf->putVar64(context.rootSpanId);
         } else {
@@ -1222,7 +1222,7 @@ class Recording {
     }
 
     void recordAllocationOutsideTLAB(Buffer* buf, int tid, u32 call_trace_id, AllocEvent* event) {
-        volatile Context context = event->_context;
+        Context context = event->_context;
 
         int start = buf->skip(1);
         buf->putVar64(T_ALLOC_OUTSIDE_TLAB);
@@ -1231,7 +1231,7 @@ class Recording {
         buf->putVar64(call_trace_id);
         buf->putVar64(event->_id);
         buf->putVar64(event->_total_size);
-        if (context.valid == 1) {
+        if (Contexts::isValid(context)) {
             buf->putVar64(context.spanId);
             buf->putVar64(context.rootSpanId);
         } else {
@@ -1255,7 +1255,7 @@ class Recording {
     }
 
     void recordMonitorBlocked(Buffer* buf, int tid, u32 call_trace_id, LockEvent* event) {
-        volatile Context context = event->_context;
+        Context context = event->_context;
 
         int start = buf->skip(1);
         buf->putVar64(T_MONITOR_ENTER);
@@ -1266,7 +1266,7 @@ class Recording {
         buf->putVar64(event->_id);
         buf->put8(0);
         buf->putVar64(event->_address);
-        if (context.valid == 1) {
+        if (Contexts::isValid(context)) {
             buf->putVar64(context.spanId);
             buf->putVar64(context.rootSpanId);
         } else {

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -39,7 +39,7 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     } else {
         tid = OS::threadId();
     }
-    Context ctx = Contexts::get(tid);
+    Context& ctx = Contexts::get(tid);
 
     ExecutionEvent event;
     event._context = ctx;

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -39,7 +39,7 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     } else {
         tid = OS::threadId();
     }
-    Context& ctx = Contexts::get(tid);
+    const Context& ctx = Contexts::get(tid);
 
     ExecutionEvent event;
     event._context = ctx;

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -190,7 +190,7 @@ bool LockTracer::isConcurrentLock(const char* lock_name) {
 void LockTracer::recordContendedLock(int event_type, u64 start_time, u64 end_time,
                                      const char* lock_name, jobject lock, jlong timeout) {
     int tid = ProfiledThread::currentTid();
-    Context ctx = Contexts::get(tid);
+    Context& ctx = Contexts::get(tid);
 
     LockEvent event;
     event._start_time = start_time;

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -190,7 +190,7 @@ bool LockTracer::isConcurrentLock(const char* lock_name) {
 void LockTracer::recordContendedLock(int event_type, u64 start_time, u64 end_time,
                                      const char* lock_name, jobject lock, jlong timeout) {
     int tid = ProfiledThread::currentTid();
-    Context& ctx = Contexts::get(tid);
+    const Context& ctx = Contexts::get(tid);
 
     LockEvent event;
     event._start_time = start_time;

--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -34,7 +34,7 @@ void ObjectSampler::SampledObjectAlloc(jvmtiEnv* jvmti, JNIEnv* jni, jthread thr
 
 void ObjectSampler::recordAllocation(jvmtiEnv* jvmti, int event_type, jclass object_klass, jlong size) {
     int tid = ProfiledThread::currentTid();
-    Context& ctx = Contexts::get(tid);
+    const Context& ctx = Contexts::get(tid);
 
     AllocEvent event;
     event._total_size = size > _interval ? size : _interval;

--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -34,7 +34,7 @@ void ObjectSampler::SampledObjectAlloc(jvmtiEnv* jvmti, JNIEnv* jni, jthread thr
 
 void ObjectSampler::recordAllocation(jvmtiEnv* jvmti, int event_type, jclass object_klass, jlong size) {
     int tid = ProfiledThread::currentTid();
-    Context ctx = Contexts::get(tid);
+    Context& ctx = Contexts::get(tid);
 
     AllocEvent event;
     event._total_size = size > _interval ? size : _interval;

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -710,7 +710,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
     int tid = current != NULL ? current->tid() : OS::threadId();
     if (_enabled) {
-        Context ctx = Contexts::get(tid);
+        Context& ctx = Contexts::get(tid);
 
         u64 counter = readCounter(siginfo, ucontext);
         ExecutionEvent event;

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -710,7 +710,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
     int tid = current != NULL ? current->tid() : OS::threadId();
     if (_enabled) {
-        Context& ctx = Contexts::get(tid);
+        const Context& ctx = Contexts::get(tid);
 
         u64 counter = readCounter(siginfo, ucontext);
         ExecutionEvent event;

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -57,7 +57,7 @@ void WallClock::sharedSignalHandler(int signo, siginfo_t* siginfo, void* ucontex
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64 last_sample) {
     ProfiledThread* current = ProfiledThread::current();
     int tid = current != NULL ? current->tid() : OS::threadId();
-    Context ctx = Contexts::get(tid);
+    Context& ctx = Contexts::get(tid);
     u64 skipped = 0;
     if (current != NULL) {
         if (_collapsing && !current->noteWallSample(false, &skipped)) {

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -57,7 +57,7 @@ void WallClock::sharedSignalHandler(int signo, siginfo_t* siginfo, void* ucontex
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64 last_sample) {
     ProfiledThread* current = ProfiledThread::current();
     int tid = current != NULL ? current->tid() : OS::threadId();
-    Context& ctx = Contexts::get(tid);
+    const Context& ctx = Contexts::get(tid);
     u64 skipped = 0;
     if (current != NULL) {
         if (_collapsing && !current->noteWallSample(false, &skipped)) {


### PR DESCRIPTION
This introduces a cheap and simple (but not flawless) mechanism to detect word tearing when threads are interrupted as contexts are written. This mechanism has false negatives but they are very unlikely, especially conditioned on the likelihood of writing a context during an interrupt.

It also passes the now much larger context objects by reference.