### PR TITLE
paginated context storage

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -19,7 +19,6 @@
 
 #include "arch.h"
 #include "arguments.h"
-#include "os.h"
 
 typedef struct {
     u64 spanId;
@@ -32,26 +31,27 @@ typedef struct {
     u64 pad5;
 } Context;
 
+// must be kept in sync with PAGE_SIZE in AsyncProfiler.java
+const u32 PAGE_SIZE = 1024;
+
 typedef struct {
     const int capacity;
     const Context* storage;
-} ContextStorage;
-
-class ContextsThreadList;
+} ContextPage;
 
 class Contexts {
-    friend class ContextsThreadList;
 
   private:
-    static int _contexts_size;
-    static Context* _contexts;
+    static Context** _pages;
+    static void initialize(int pageIndex);
 
   public:
-    static void initialize();
+    // get and isValid must not allocate
     static const Context& get(int tid);
     static bool isValid(const Context& context);
     // not to be called except to share with Java callers as a DirectByteBuffer
-    static ContextStorage getStorage();
+    static ContextPage getPage(int tid);
+    static int getMaxPages();
 };
 
 #endif /* _CONTEXT_H */

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -139,14 +139,18 @@ Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jthre
 }
 
 extern "C" DLLEXPORT jobject JNICALL
-Java_one_profiler_AsyncProfiler_getContextStorage0(JNIEnv* env, jobject unused) {
-    ContextStorage storage = Contexts::getStorage();
-    return env->NewDirectByteBuffer((void*) storage.storage, (jlong) storage.capacity);
+Java_one_profiler_AsyncProfiler_getContextPage0(JNIEnv* env, jobject unused, jint tid) {
+    ContextPage page = Contexts::getPage((int) tid);
+    return env->NewDirectByteBuffer((void*) page.storage, (jlong) page.capacity);
 }
 
 extern "C" DLLEXPORT jint JNICALL
-Java_one_profiler_AsyncProfiler_getNativePointerSize0(JNIEnv* env, jobject unused) {
-    return sizeof(void*);
+Java_one_profiler_AsyncProfiler_getMaxContextPages0(JNIEnv* env, jobject unused) {
+    if (sizeof(void*) == 8) {
+        return (jint) Contexts::getMaxPages();
+    }
+    // feature disabled on 32 bit systems
+    return 0;
 }
 
 #define F(name, sig)  {(char*)#name, (char*)sig, (void*)Java_one_profiler_AsyncProfiler_##name}
@@ -158,8 +162,8 @@ static const JNINativeMethod profiler_natives[] = {
     F(getSamples,            "()J"),
     F(filterThread0,         "(Ljava/lang/Thread;Z)V"),
     F(getTid0,               "()I"),
-    F(getContextStorage0,    "()Ljava/nio/ByteBuffer"),
-    F(getNativePointerSize0, "()I")
+    F(getContextPage0,       "(I)Ljava/nio/ByteBuffer"),
+    F(getMaxContextPages0,   "()I")
 };
 
 static const JNINativeMethod* execute0 = &profiler_natives[2];

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -135,8 +135,6 @@ bool VM::init(JavaVM* vm, bool attach) {
     _asyncGetCallTrace = (AsyncGetCallTrace)dlsym(_libjvm, "AsyncGetCallTrace");
     _getManagement = (JVM_GetManagement)dlsym(_libjvm, "JVM_GetManagement");
 
-    Contexts::initialize();
-
     Profiler* profiler = Profiler::instance();
     profiler->updateSymbols(false);
 


### PR DESCRIPTION
The max thread id can be very large (2^18 in CI, for example) and allocating enough contexts for the maximum thread id up front is wasteful. This introduces a paginated structure which allocates pages of 1024 contexts (64KiB) when Java threads try to set context for the first time from a thread with a tid in in a contiguous range. On the native side, there is no allocation, and if context is looked up for a thread on a null page, an empty context is retrieved.