### PR TITLE
remove wallclock sample collapsing and weight from `datadog.MethodSample`/`datadog.ExecutionSample` events

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -190,7 +190,7 @@ Error Arguments::parse(const char* args) {
                     _wall = 0;
                 } else {
                     if (value[0] == '~') {
-                        _wall_collapsing = true;
+                        // backward compatability - we just won't collapse the events
                         _wall = parseUnits(value + 1, NANOS);
                     } else {
                         _wall = parseUnits(value, NANOS);

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -142,7 +142,6 @@ class Arguments {
     long _cpu;
     int _cpu_threads_per_tick;
     long _wall;
-    bool _wall_collapsing;
     int _wall_threads_per_tick;
     long _alloc;
     long _lock;
@@ -189,7 +188,6 @@ class Arguments {
         _cpu(-1),
         _cpu_threads_per_tick(DEFAULT_CPU_THREADS_PER_TICK),
         _wall(-1),
-        _wall_collapsing(false),
         _wall_threads_per_tick(DEFAULT_WALL_THREADS_PER_TICK),
         _alloc(-1),
         _lock(-1),

--- a/src/event.h
+++ b/src/event.h
@@ -38,9 +38,8 @@ class Event {
 class ExecutionEvent : public Event {
   public:
     ThreadState _thread_state;
-    u64 _weight;
 
-    ExecutionEvent() : Event(), _thread_state(THREAD_RUNNING), _weight(1) {}
+    ExecutionEvent() : Event(), _thread_state(THREAD_RUNNING) {}
 };
 
 class AllocEvent : public Event {

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1176,7 +1176,6 @@ class Recording {
             buf->putVar64(0);
             buf->putVar64(0);
         }
-        buf->putVar64(event->_weight);
         buf->put8(start, buf->offset() - start);
     }
 
@@ -1196,7 +1195,6 @@ class Recording {
             buf->putVar64(0);
             buf->putVar64(0);
         }
-        buf->putVar64(event->_weight);
         buf->put8(start, buf->offset() - start);
     }
 

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -34,7 +34,6 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     int tid = 0;
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {
-        current->noteCPUSample();
         tid = current->tid();
     } else {
         tid = OS::threadId();

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -100,8 +100,7 @@ void JfrMetadata::initialize() {
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                 << field("spanId", T_LONG, "Span ID")
-                << field("localRootSpanId", T_LONG, "Local Root Span ID")
-                << field("weight", T_LONG, "Sample weight"))
+                << field("localRootSpanId", T_LONG, "Local Root Span ID"))
 
             << (type("datadog.MethodSample", T_METHOD_SAMPLE, "Method Wall Profiling Sample")
                 << category("Datadog", "Profiling")
@@ -110,8 +109,7 @@ void JfrMetadata::initialize() {
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                 << field("spanId", T_LONG, "Span ID")
-                << field("localRootSpanId", T_LONG, "Local Root Span ID")
-                << field("weight", T_LONG, "Sample weight"))
+                << field("localRootSpanId", T_LONG, "Local Root Span ID"))
 
             << (type("datadog.ObjectAllocationInNewTLAB", T_ALLOC_IN_NEW_TLAB, "Allocation in new TLAB")
                 << category("Java Application")

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -705,9 +705,6 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
 
     ProfiledThread* current = ProfiledThread::current();
-    if (current != NULL) {
-        current->noteCPUSample();
-    }
     int tid = current != NULL ? current->tid() : OS::threadId();
     if (_enabled) {
         const Context& ctx = Contexts::get(tid);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -157,23 +157,6 @@ void ProfiledThread::releaseFromBuffer() {
     }
 }
 
-bool ProfiledThread::noteWallSample(bool all, u64* skipped_samples) {
-    if (all) {
-        _wall_epoch = _cpu_epoch;
-        *skipped_samples = 0;
-        return true;
-    }
-
-    if (_wall_epoch == _cpu_epoch) {
-        *skipped_samples = ++_skipped_samples;
-        return false;
-    }
-    _wall_epoch = _cpu_epoch;
-    *skipped_samples = _skipped_samples;
-    _skipped_samples = 0;
-    return true;
-}
-
 inline ProfiledThread* ProfiledThread::current() {
     pthread_key_t key = _tls_key;
     return key != 0 ? (ProfiledThread*) pthread_getspecific(key) : NULL;

--- a/src/thread.h
+++ b/src/thread.h
@@ -25,11 +25,8 @@ class ProfiledThread {
 
     int _buffer_pos;
     int _tid;
-    u64 _cpu_epoch;
-    u64 _wall_epoch;
-    u64 _skipped_samples;
 
-    ProfiledThread(int buffer_pos, int tid) :  _buffer_pos(buffer_pos), _tid(tid), _cpu_epoch(0), _wall_epoch(0), _skipped_samples(0) {};
+    ProfiledThread(int buffer_pos, int tid) :  _buffer_pos(buffer_pos), _tid(tid) {};
 
     void releaseFromBuffer();
   public:
@@ -57,14 +54,6 @@ class ProfiledThread {
     inline int tid() {
         return _tid;
     }
-
-    inline u64 getCpuEpoch() {
-        return _cpu_epoch;
-    }
-    inline u64 noteCPUSample() {
-        return ++_cpu_epoch;
-    }
-    bool noteWallSample(bool all, u64* skipped_samples);
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 };

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -26,7 +26,6 @@
 class WallClock : public Engine {
   private:
     static volatile bool _enabled;
-    bool _collapsing;
     long _interval;
 
     // Maximum number of threads sampled in one iteration. This limit serves as a throttle
@@ -52,7 +51,6 @@ class WallClock : public Engine {
 
   public:
     constexpr WallClock() :
-        _collapsing(false),
         _interval(LONG_MAX),
         _reservoir_size(0),
         _running(false),


### PR DESCRIPTION
Now we have context labels and sample from a thread filter, the weights are buggy and would not be very effective in deduplicating events.