### PR TITLE
Revert "remove wallclock sample collapsing and weight from `datadog.MethodSample`/`datadog.ExecutionSample` events"

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -190,7 +190,7 @@ Error Arguments::parse(const char* args) {
                     _wall = 0;
                 } else {
                     if (value[0] == '~') {
-                        // backward compatability - we just won't collapse the events
+                        _wall_collapsing = true;
                         _wall = parseUnits(value + 1, NANOS);
                     } else {
                         _wall = parseUnits(value, NANOS);

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -142,6 +142,7 @@ class Arguments {
     long _cpu;
     int _cpu_threads_per_tick;
     long _wall;
+    bool _wall_collapsing;
     int _wall_threads_per_tick;
     long _alloc;
     long _lock;
@@ -188,6 +189,7 @@ class Arguments {
         _cpu(-1),
         _cpu_threads_per_tick(DEFAULT_CPU_THREADS_PER_TICK),
         _wall(-1),
+        _wall_collapsing(false),
         _wall_threads_per_tick(DEFAULT_WALL_THREADS_PER_TICK),
         _alloc(-1),
         _lock(-1),

--- a/src/event.h
+++ b/src/event.h
@@ -38,8 +38,9 @@ class Event {
 class ExecutionEvent : public Event {
   public:
     ThreadState _thread_state;
+    u64 _weight;
 
-    ExecutionEvent() : Event(), _thread_state(THREAD_RUNNING) {}
+    ExecutionEvent() : Event(), _thread_state(THREAD_RUNNING), _weight(1) {}
 };
 
 class AllocEvent : public Event {

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1176,6 +1176,7 @@ class Recording {
             buf->putVar64(0);
             buf->putVar64(0);
         }
+        buf->putVar64(event->_weight);
         buf->put8(start, buf->offset() - start);
     }
 
@@ -1195,6 +1196,7 @@ class Recording {
             buf->putVar64(0);
             buf->putVar64(0);
         }
+        buf->putVar64(event->_weight);
         buf->put8(start, buf->offset() - start);
     }
 

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -34,6 +34,7 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     int tid = 0;
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {
+        current->noteCPUSample();
         tid = current->tid();
     } else {
         tid = OS::threadId();

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -100,7 +100,8 @@ void JfrMetadata::initialize() {
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                 << field("spanId", T_LONG, "Span ID")
-                << field("localRootSpanId", T_LONG, "Local Root Span ID"))
+                << field("localRootSpanId", T_LONG, "Local Root Span ID")
+                << field("weight", T_LONG, "Sample weight"))
 
             << (type("datadog.MethodSample", T_METHOD_SAMPLE, "Method Wall Profiling Sample")
                 << category("Datadog", "Profiling")
@@ -109,7 +110,8 @@ void JfrMetadata::initialize() {
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                 << field("spanId", T_LONG, "Span ID")
-                << field("localRootSpanId", T_LONG, "Local Root Span ID"))
+                << field("localRootSpanId", T_LONG, "Local Root Span ID")
+                << field("weight", T_LONG, "Sample weight"))
 
             << (type("datadog.WallClockSamplingEpoch", T_WALLCLOCK_SAMPLE_EPOCH, "WallClock Sampling Epoch")
                 << category("Datadog", "Profiling")

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -705,6 +705,9 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
 
     ProfiledThread* current = ProfiledThread::current();
+    if (current != NULL) {
+        current->noteCPUSample();
+    }
     int tid = current != NULL ? current->tid() : OS::threadId();
     if (_enabled) {
         const Context& ctx = Contexts::get(tid);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -157,6 +157,23 @@ void ProfiledThread::releaseFromBuffer() {
     }
 }
 
+bool ProfiledThread::noteWallSample(bool all, u64* skipped_samples) {
+    if (all) {
+        _wall_epoch = _cpu_epoch;
+        *skipped_samples = 0;
+        return true;
+    }
+
+    if (_wall_epoch == _cpu_epoch) {
+        *skipped_samples = ++_skipped_samples;
+        return false;
+    }
+    _wall_epoch = _cpu_epoch;
+    *skipped_samples = _skipped_samples;
+    _skipped_samples = 0;
+    return true;
+}
+
 inline ProfiledThread* ProfiledThread::current() {
     pthread_key_t key = _tls_key;
     return key != 0 ? (ProfiledThread*) pthread_getspecific(key) : NULL;

--- a/src/thread.h
+++ b/src/thread.h
@@ -25,8 +25,11 @@ class ProfiledThread {
 
     int _buffer_pos;
     int _tid;
+    u64 _cpu_epoch;
+    u64 _wall_epoch;
+    u64 _skipped_samples;
 
-    ProfiledThread(int buffer_pos, int tid) :  _buffer_pos(buffer_pos), _tid(tid) {};
+    ProfiledThread(int buffer_pos, int tid) :  _buffer_pos(buffer_pos), _tid(tid), _cpu_epoch(0), _wall_epoch(0), _skipped_samples(0) {};
 
     void releaseFromBuffer();
   public:
@@ -54,6 +57,14 @@ class ProfiledThread {
     inline int tid() {
         return _tid;
     }
+
+    inline u64 getCpuEpoch() {
+        return _cpu_epoch;
+    }
+    inline u64 noteCPUSample() {
+        return ++_cpu_epoch;
+    }
+    bool noteWallSample(bool all, u64* skipped_samples);
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 };

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -59,10 +59,17 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64
     ProfiledThread* current = ProfiledThread::current();
     int tid = current != NULL ? current->tid() : OS::threadId();
     const Context& ctx = Contexts::get(tid);
+    u64 skipped = 0;
+    if (current != NULL) {
+        if (_collapsing && !current->noteWallSample(false, &skipped)) {
+            return;
+        }
+    }
 
     ExecutionEvent event;
     event._context = ctx;
     event._thread_state = getThreadState(ucontext);
+    event._weight = skipped + 1;
     Profiler::instance()->recordSample(ucontext, last_sample, tid, BCI_WALL, &event);
 }
 
@@ -72,6 +79,8 @@ Error WallClock::start(Arguments &args) {
         return Error("interval must be positive");
     }
     _interval = interval ? interval : DEFAULT_WALL_INTERVAL;
+
+    _collapsing = args._wall_collapsing;
 
     _reservoir_size =
             args._wall_threads_per_tick ?

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -26,6 +26,7 @@
 class WallClock : public Engine {
   private:
     static volatile bool _enabled;
+    bool _collapsing;
     long _interval;
 
     // Maximum number of threads sampled in one iteration. This limit serves as a throttle
@@ -51,6 +52,7 @@ class WallClock : public Engine {
 
   public:
     constexpr WallClock() :
+        _collapsing(false),
         _interval(LONG_MAX),
         _reservoir_size(0),
         _running(false),


### PR DESCRIPTION
Reverts DataDog/async-profiler#107

Removing this increased recording sizes significantly, so it needs to be reworked to work with context instead