### PR TITLE
context sensitive sample deduplication

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -157,17 +157,18 @@ void ProfiledThread::releaseFromBuffer() {
     }
 }
 
-bool ProfiledThread::noteWallSample(bool all, u64* skipped_samples) {
+bool ProfiledThread::noteWallSample(bool all, u64 context_key, u64* skipped_samples) {
     if (all) {
         _wall_epoch = _cpu_epoch;
         *skipped_samples = 0;
         return true;
     }
 
-    if (_wall_epoch == _cpu_epoch) {
+    if (_wall_epoch == _cpu_epoch && _context_key == context_key) {
         *skipped_samples = ++_skipped_samples;
         return false;
     }
+    _context_key = context_key;
     _wall_epoch = _cpu_epoch;
     *skipped_samples = _skipped_samples;
     _skipped_samples = 0;

--- a/src/thread.h
+++ b/src/thread.h
@@ -28,8 +28,15 @@ class ProfiledThread {
     u64 _cpu_epoch;
     u64 _wall_epoch;
     u64 _skipped_samples;
+    u64 _context_key;
 
-    ProfiledThread(int buffer_pos, int tid) :  _buffer_pos(buffer_pos), _tid(tid), _cpu_epoch(0), _wall_epoch(0), _skipped_samples(0) {};
+    ProfiledThread(int buffer_pos, int tid) :
+        _buffer_pos(buffer_pos),
+        _tid(tid),
+        _cpu_epoch(0),
+        _wall_epoch(0),
+        _skipped_samples(0),
+        _context_key(0) {};
 
     void releaseFromBuffer();
   public:
@@ -64,7 +71,7 @@ class ProfiledThread {
     inline u64 noteCPUSample() {
         return ++_cpu_epoch;
     }
-    bool noteWallSample(bool all, u64* skipped_samples);
+    bool noteWallSample(bool all, u64 context_key, u64* skipped_samples);
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 };

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -61,7 +61,7 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64
     const Context& ctx = Contexts::get(tid);
     u64 skipped = 0;
     if (current != NULL) {
-        if (_collapsing && !current->noteWallSample(false, &skipped)) {
+        if (_collapsing && !current->noteWallSample(false, ctx.spanId, &skipped)) {
             return;
         }
     }


### PR DESCRIPTION
This stores a 64 bit context key in `ProfiledThread` and uses it to check if the context has changed when deduplicating samples. If it has changed, deduplication cannot be done. The approach is pragmatic and uses the spanId to identify contexts, and accepts a practically zero risk of collision in exchange for not storing a copy of the much larger context object in each `ProfiledThread`.