### PR TITLE
fix thread filtering crash

### DIFF
--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -130,12 +130,12 @@ Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jthre
     } else if ((thread_id = VMThread::nativeThreadId(env, thread)) < 0) {
         return;
     }
-
-    if (WallClock* wall_engine = dynamic_cast<WallClock*>(Profiler::instance()->wallEngine())) {
+    Engine* engine = Profiler::instance()->wallEngine();
+    if (engine != NULL) {
         if (enable) {
-            wall_engine->registerThread(thread_id);
+            engine->registerThread(thread_id);
         } else {
-            wall_engine->unregisterThread(thread_id);
+            engine->unregisterThread(thread_id);
         }
     }
 }

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -90,7 +90,7 @@ class Profiler {
     CallTraceStorage _call_trace_storage;
     FlightRecorder _jfr;
     Engine* _cpu_engine;
-    Engine* _wall_engine;
+    Engine* _wall_engine = NULL;
     Engine* _alloc_engine;
     int _event_mask;
 

--- a/test/maven/java/filter/ThreadFilterSmokeTest.java
+++ b/test/maven/java/filter/ThreadFilterSmokeTest.java
@@ -1,0 +1,61 @@
+package filter;
+
+import one.profiler.AsyncProfiler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ThreadFilterSmokeTest {
+  private ExecutorService executorService;
+
+  @BeforeEach
+  public void before() {
+    executorService = Executors.newCachedThreadPool();
+  }
+
+  @AfterEach
+  public void after() {
+    executorService.shutdownNow();
+  }
+
+  @Test
+  public void smokeTest() throws Exception {
+    Path jfrDump = Files.createTempFile("filter-test", ".jfr");
+    AsyncProfiler asyncProfiler = AsyncProfiler.getInstance();
+    doThreadFiltering(asyncProfiler);
+    asyncProfiler.execute("start,wall=~1ms,filter=0,jfr,thread,file=" + jfrDump.toAbsolutePath());
+    doThreadFiltering(asyncProfiler);
+  }
+
+  private void doThreadFiltering(AsyncProfiler asyncProfiler) throws Exception {
+    Future<?>[] futures = new Future[1000];
+    for (int i = 0; i < futures.length; i++) {
+      int id = i;
+      futures[i] = executorService.submit(new Runnable() {
+        @Override
+        public void run() {
+          asyncProfiler.addThread(Thread.currentThread());
+          asyncProfiler.setContext(id, 42);
+          try {
+            Thread.sleep(2);
+          } catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          asyncProfiler.removeThread(Thread.currentThread());
+        }
+      });
+    }
+    for (Future<?> future : futures) {
+      future.get();
+    }
+  }
+}


### PR DESCRIPTION
dd-trace-java smoke tests caught the `_wall_engine` pointer being accessed before intialisation. Preventing this from happening needs fixing in dd-trace-java for the sake of correctness (it means threads would be missed), but this prevents crashes

```
---------------  T H R E A D  ---------------

Current thread (0x0000563c62543800):  JavaThread "default I/O-34" [_thread_in_native, id=13808, stack(0x00007f40edbb6000,0x00007f40edcb7000)]

Stack: [0x00007f40edbb6000,0x00007f40edcb7000],  sp=0x00007f40edcb4ef0,  free space=1019k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libstdc++.so.6+0xa8e26]  __dynamic_cast+0x56
j  one.profiler.AsyncProfiler.filterThread0(Ljava/lang/Thread;Z)V+0
j  one.profiler.AsyncProfiler.filterThread(Ljava/lang/Thread;Z)V+14
j  one.profiler.AsyncProfiler.addThread(Ljava/lang/Thread;)V+3
j  com.datadog.profiling.async.AsyncProfiler.addCurrentThread()V+14
j  com.datadog.profiling.async.ContextThreadFilter.onAttach()V+9
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ScopeStackThreadLocal$1.run()V+33
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ScopeStack.notifyOnFirstPush()V+16
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ScopeStack.push(Ldatadog/trace/agent/core/scopemanager/ContinuableScopeManager$ContinuableScope;)V+1
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager.activate(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;BZZ)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+141
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager.activate(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;Ldatadog/trace/bootstrap/instrumentation/api/ScopeSource;Z)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+8
j  datadog.trace.agent.core.CoreTracer.activateSpan(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;Ldatadog/trace/bootstrap/instrumentation/api/ScopeSource;Z)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+7
j  datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+8
j  io.undertow.server.handlers.DisallowedMethodsHandler.handleRequest(Lio/undertow/server/HttpServerExchange;)V+64
j  io.undertow.server.Connectors.executeRootHandler(Lio/undertow/server/HttpHandler;Lio/undertow/server/HttpServerExchange;)V+8
j  io.undertow.server.protocol.http.HttpReadListener.handleEventWithNoRunningRequest(Lorg/xnio/conduits/ConduitStreamSourceChannel;)V+792
j  io.undertow.server.protocol.http.HttpReadListener.handleEvent(Lorg/xnio/conduits/ConduitStreamSourceChannel;)V+51
j  io.undertow.server.protocol.http.HttpReadListener.handleEvent(Ljava/nio/channels/Channel;)V+5
j  org.xnio.ChannelListeners.invokeChannelListener(Ljava/nio/channels/Channel;Lorg/xnio/ChannelListener;)Z+18
j  org.xnio.conduits.ReadReadyHandler$ChannelListenerHandler.readReady()V+34
j  org.xnio.nio.NioSocketConduit.handleReady(I)V+51
j  org.xnio.nio.WorkerThread.run()V+1047
v  ~StubRoutines::call_stub
V  [libjvm.so+0x85ae93]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x313
V  [libjvm.so+0x859130]  JavaCalls::call_virtual(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, Thread*)+0x160
V  [libjvm.so+0x859201]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, Thread*)+0x81
V  [libjvm.so+0x8fb3ec]  thread_entry(JavaThread*, Thread*)+0x6c
V  [libjvm.so+0xd390e0]  JavaThread::thread_main_inner()+0xd0
V  [libjvm.so+0xd351a9]  Thread::call_run()+0x149
V  [libjvm.so+0xba7fa6]  thread_native_entry(Thread*)+0xe6

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  one.profiler.AsyncProfiler.filterThread0(Ljava/lang/Thread;Z)V+0
j  one.profiler.AsyncProfiler.filterThread(Ljava/lang/Thread;Z)V+14
j  one.profiler.AsyncProfiler.addThread(Ljava/lang/Thread;)V+3
j  com.datadog.profiling.async.AsyncProfiler.addCurrentThread()V+14
j  com.datadog.profiling.async.ContextThreadFilter.onAttach()V+9
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ScopeStackThreadLocal$1.run()V+33
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ScopeStack.notifyOnFirstPush()V+16
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager$ScopeStack.push(Ldatadog/trace/agent/core/scopemanager/ContinuableScopeManager$ContinuableScope;)V+1
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager.activate(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;BZZ)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+141
j  datadog.trace.agent.core.scopemanager.ContinuableScopeManager.activate(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;Ldatadog/trace/bootstrap/instrumentation/api/ScopeSource;Z)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+8
j  datadog.trace.agent.core.CoreTracer.activateSpan(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;Ldatadog/trace/bootstrap/instrumentation/api/ScopeSource;Z)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+7
j  datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan(Ldatadog/trace/bootstrap/instrumentation/api/AgentSpan;)Ldatadog/trace/bootstrap/instrumentation/api/AgentScope;+8
j  io.undertow.server.handlers.DisallowedMethodsHandler.handleRequest(Lio/undertow/server/HttpServerExchange;)V+64
j  io.undertow.server.Connectors.executeRootHandler(Lio/undertow/server/HttpHandler;Lio/undertow/server/HttpServerExchange;)V+8
j  io.undertow.server.protocol.http.HttpReadListener.handleEventWithNoRunningRequest(Lorg/xnio/conduits/ConduitStreamSourceChannel;)V+792
j  io.undertow.server.protocol.http.HttpReadListener.handleEvent(Lorg/xnio/conduits/ConduitStreamSourceChannel;)V+51
j  io.undertow.server.protocol.http.HttpReadListener.handleEvent(Ljava/nio/channels/Channel;)V+5
j  org.xnio.ChannelListeners.invokeChannelListener(Ljava/nio/channels/Channel;Lorg/xnio/ChannelListener;)Z+18
j  org.xnio.conduits.ReadReadyHandler$ChannelListenerHandler.readReady()V+34
j  org.xnio.nio.NioSocketConduit.handleReady(I)V+51
j  org.xnio.nio.WorkerThread.run()V+1047
v  ~StubRoutines::call_stub

siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000000

Register to memory mapping:

RAX=0x00007f411ac9e450: <offset 0x000000000127b450> in /usr/lib/jvm/openjdk11/lib/server/libjvm.so at 0x00007f4119a23000
RBX=0x0000563c5c9f0b88 points into unknown readable memory: 0x00007f411ac9e450 | 50 e4 c9 1a 41 7f 00 00
RCX=0x0 is NULL
RDX=0x00007f40f7c6a8d0: <offset 0x00000000002388d0> in /tmp/libasyncProfiler2459674316061266779.so at 0x00007f40f7a32000
RSP=0x00007f40edcb4ef0 is pointing into the stack for thread: 0x0000563c62543800
RBP=0x00007f40edcb4f60 is pointing into the stack for thread: 0x0000563c62543800
RSI=0x00007f40f7c6a760: <offset 0x0000000000238760> in /tmp/libasyncProfiler2459674316061266779.so at 0x00007f40f7a32000
RDI=0x0 is NULL
R8 =0x0000563c5c9f0b88 points into unknown readable memory: 0x00007f411ac9e450 | 50 e4 c9 1a 41 7f 00 00
R9 =0x0 is NULL
R10=0xfffffffffffffaf8 is an unknown value
R11=0x00007f40f78f8dd0: __dynamic_cast+0x0000000000000000 in /lib/x86_64-linux-gnu/libstdc++.so.6 at 0x00007f40f7850000
R12=0x0000000000000001 is an unknown value
R13={method} {0x00007f40f7faa7d0} 'filterThread0' '(Ljava/lang/Thread;Z)V' in 'one/profiler/AsyncProfiler'
R14=0x00007f40edcb5008 is pointing into the stack for thread: 0x0000563c62543800
R15=0x0000563c62543800 is a thread
```