### PR TITLE
record reason for sample error

### DIFF
--- a/src/event.h
+++ b/src/event.h
@@ -73,6 +73,8 @@ class WallClockEpochEvent {
     u32 _num_samplable_threads;
     u32 _num_successful_samples;
     u32 _num_failed_samples;
+    u32 _num_exited_threads;
+    u32 _num_permission_denied;
 
     WallClockEpochEvent(u64 start_time) :
         _dirty(false),
@@ -80,7 +82,9 @@ class WallClockEpochEvent {
         _duration_millis(0),
         _num_samplable_threads(0),
         _num_successful_samples(0),
-        _num_failed_samples(0) {}
+        _num_failed_samples(0),
+        _num_exited_threads(0),
+        _num_permission_denied(0) {}
 
     bool hasChanged() {
         return _dirty;
@@ -104,6 +108,20 @@ class WallClockEpochEvent {
         if (_num_failed_samples != num_failed_samples) {
             _dirty = true;
             _num_failed_samples = num_failed_samples;
+        }
+    }
+
+    void updateNumExitedThreads(u32 num_exited_threads) {
+        if (_num_exited_threads != num_exited_threads) {
+            _dirty = true;
+            _num_exited_threads = num_exited_threads;
+        }
+    }
+
+    void updateNumPermissionDenied(u32 num_permission_denied) {
+        if (_num_permission_denied != num_permission_denied) {
+            _dirty = true;
+            _num_permission_denied = num_permission_denied;
         }
     }
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1198,6 +1198,8 @@ class Recording {
         buf->putVar64(event->_num_samplable_threads);
         buf->putVar64(event->_num_successful_samples);
         buf->putVar64(event->_num_failed_samples);
+        buf->putVar64(event->_num_exited_threads);
+        buf->putVar64(event->_num_permission_denied);
         buf->put8(start, buf->offset() - start);
     }
 

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -119,7 +119,9 @@ void JfrMetadata::initialize() {
                 << field("duration", T_LONG, "Duration", F_DURATION_MILLIS)
                 << field("samplePoolSize", T_INT, "Sample Pool Size")
                 << field("numSuccessfulSamples", T_INT, "Number of Successful Samples")
-                << field("numFailedSamples", T_INT, "Number of Failed Samples"))
+                << field("numFailedSamples", T_INT, "Number of Failed Samples")
+                << field("numExitedThreads", T_INT, "Number of Exited Threads Before Handling Signal")
+                << field("numPermissionDenied", T_INT, "Number of Permission Denied Errors"))
 
             << (type("datadog.ObjectAllocationInNewTLAB", T_ALLOC_IN_NEW_TLAB, "Allocation in new TLAB")
                 << category("Java Application")


### PR DESCRIPTION
Record reasons for signal errors as documented here: https://man7.org/linux/man-pages/man2/tgkill.2.html

EINVAL is impossible by construction because we use a thread-filter, and I don't believe EAGAIN applies to SIGVTALRM.