### PR TITLE
accept tid directly in filterThread to avoid syscall overhead

### DIFF
--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -189,35 +189,22 @@ public class AsyncProfiler {
      * Add the given thread to the set of profiled threads.
      * 'filter' option must be enabled to use this method.
      *
-     * @param thread Thread to include in profiling
+     * @param tid native thread id to include in profiling
      */
-    public void addThread(Thread thread) {
-        filterThread(thread, true);
+    public void addThread(int tid) {
+        filterThread0(tid, true);
     }
 
     /**
-     * Remove the given thread from the set of profiled threads.
+     * Remove the given thread to the set of profiled threads.
      * 'filter' option must be enabled to use this method.
      *
-     * @param thread Thread to exclude from profiling
+     * @param tid native thread id to remove from profiling
      */
-    public void removeThread(Thread thread) {
-        filterThread(thread, false);
+    public void removeThread(int tid) {
+        filterThread0(tid, false);
     }
 
-    private void filterThread(Thread thread, boolean enable) {
-        if (thread == null || thread == Thread.currentThread()) {
-            filterThread0(null, enable);
-        } else {
-            // Need to take lock to avoid race condition with a thread state change
-            synchronized (thread) {
-                Thread.State state = thread.getState();
-                if (state != Thread.State.NEW && state != Thread.State.TERMINATED) {
-                    filterThread0(thread, enable);
-                }
-            }
-        }
-    }
 
     /**
      * Passing context identifier to a profiler. This ID is thread-local and is dumped in
@@ -276,7 +263,7 @@ public class AsyncProfiler {
     private native void start0(String event, long interval, boolean reset) throws IllegalStateException;
     private native void stop0() throws IllegalStateException;
     private native String execute0(String command) throws IllegalArgumentException, IllegalStateException, IOException;
-    private native void filterThread0(Thread thread, boolean enable);
+    private native void filterThread0(int tid, boolean enable);
 
     private static native int getTid0();
     private static native ByteBuffer getContextPage0(int tid);

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -123,18 +123,15 @@ Java_one_profiler_AsyncProfiler_getSamples(JNIEnv* env, jobject unused) {
 }
 
 extern "C" DLLEXPORT void JNICALL
-Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jthread thread, jboolean enable) {
-    int thread_id;
-    if (thread == NULL) {
-        thread_id = OS::threadId();
-    } else if ((thread_id = VMThread::nativeThreadId(env, thread)) < 0) {
+Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jint tid, jboolean enable) {
+    if (tid < 0) {
         return;
     }
     ThreadFilter* thread_filter = Profiler::instance()->threadFilter();
     if (enable) {
-        thread_filter->add(thread_id);
+        thread_filter->add(tid);
     } else {
-        thread_filter->remove(thread_id);
+        thread_filter->remove(tid);
     }
 }
 
@@ -160,7 +157,7 @@ static const JNINativeMethod profiler_natives[] = {
     F(stop0,                 "()V"),
     F(execute0,              "(Ljava/lang/String;)Ljava/lang/String;"),
     F(getSamples,            "()J"),
-    F(filterThread0,         "(Ljava/lang/Thread;Z)V"),
+    F(filterThread0,         "(I;Z)V"),
     F(getTid0,               "()I"),
     F(getContextPage0,       "(I)Ljava/nio/ByteBuffer"),
     F(getMaxContextPages0,   "()I")

--- a/test/ContextTarget.java
+++ b/test/ContextTarget.java
@@ -15,11 +15,12 @@ public class ContextTarget {
     }
 
     public static void main(String[] args) {
-        ap.addThread(Thread.currentThread());
+        int tid = ap.getNativeThreadId();
+        ap.addThread(tid);
         long ts = System.nanoTime();
         entry(200, 750);
         System.err.println("===> time: " + (System.nanoTime() - ts) + "ns");
-        ap.removeThread(Thread.currentThread());
+        ap.removeThread(tid);
     }
 
     // @Trace(operationName = "doEntry")

--- a/test/maven/java/context/ContextTest.java
+++ b/test/maven/java/context/ContextTest.java
@@ -35,7 +35,7 @@ public class ContextTest {
     public void testReadContext() throws Exception {
         Path jfrDump = Files.createTempFile("context-test", ".jfr");
         AsyncProfiler ap = AsyncProfiler.getInstance(Utils.getAsyncProfilerLib());
-        ap.addThread(Thread.currentThread());
+        ap.addThread(ap.getNativeThreadId());
         ap.setContext(42, 84);
         ap.execute("start,cpu=1ms,jfr,thread,file=" + jfrDump.toAbsolutePath());
         // do some work to get some cpu samples

--- a/test/maven/java/filter/ThreadFilterSmokeTest.java
+++ b/test/maven/java/filter/ThreadFilterSmokeTest.java
@@ -44,14 +44,15 @@ public class ThreadFilterSmokeTest {
       futures[i] = executorService.submit(new Runnable() {
         @Override
         public void run() {
-          asyncProfiler.addThread(Thread.currentThread());
+          int tid = asyncProfiler.getNativeThreadId();
+          asyncProfiler.addThread(tid);
           asyncProfiler.setContext(id, 42);
           try {
             Thread.sleep(2);
           } catch(InterruptedException e) {
             Thread.currentThread().interrupt();
           }
-          asyncProfiler.removeThread(Thread.currentThread());
+          asyncProfiler.removeThread(tid);
         }
       });
     }

--- a/test/maven/java/linkage/AsyncProfilerLinkageTest.java
+++ b/test/maven/java/linkage/AsyncProfilerLinkageTest.java
@@ -10,7 +10,7 @@ public class AsyncProfilerLinkageTest {
     @Test
     public void testContextApiLinked() throws Exception {
         AsyncProfiler ap = AsyncProfiler.getInstance(Utils.getAsyncProfilerLib());
-        ap.addThread(Thread.currentThread());
+        ap.addThread(ap.getNativeThreadId());
         ap.setContext(1, 1);
         ap.clearContext();
     }

--- a/test/maven/java/shutdown/ShutdownTest.java
+++ b/test/maven/java/shutdown/ShutdownTest.java
@@ -27,14 +27,14 @@ public class ShutdownTest {
   @Test
   public void testShutdownWall() throws IOException {
     AsyncProfiler ap = AsyncProfiler.getInstance(Utils.getAsyncProfilerLib());
-    ap.addThread(Thread.currentThread());
+    ap.addThread(ap.getNativeThreadId());
     runTest(ap, "start,wall=~10us,filter=0,thread");
   }
 
   @Test
   public void testShutdownCpuAndWall() throws IOException {
     AsyncProfiler ap = AsyncProfiler.getInstance(Utils.getAsyncProfilerLib());
-    ap.addThread(Thread.currentThread());
+    ap.addThread(ap.getNativeThreadId());
     runTest(ap, "start,cpu=10us,wall=~10us,filter=0,thread");
   }
 


### PR DESCRIPTION
Since we can cache the native tid in another thread-local on the Java side, we don't need to incur syscall overhead looking it up when we call `filterThread0`