### PR TITLE
hard disable native traces for allocation events

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -317,12 +317,13 @@ bool Profiler::isAddressInCode(uintptr_t addr) {
 }
 
 int Profiler::getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, int event_type, int tid, StackContext* java_ctx, bool *truncated) {
-    const void* callchain[MAX_NATIVE_FRAMES];
-    int native_frames = 0;
-
-    if (_cstack == CSTACK_NO || (event_type != BCI_CPU && event_type != BCI_WALL && _cstack == CSTACK_DEFAULT)) {
+    if (_cstack == CSTACK_NO
+        || (event_type == BCI_ALLOC || event_type == BCI_ALLOC_OUTSIDE_TLAB)
+        || (event_type != BCI_CPU && event_type != BCI_WALL && _cstack == CSTACK_DEFAULT)) {
         return 0;
     }
+    const void* callchain[MAX_NATIVE_FRAMES];
+    int native_frames = 0;
 
     if (event_type == BCI_CPU && _cpu_engine == &perf_events) {
         native_frames += PerfEvents::walkKernel(tid, callchain + native_frames, MAX_NATIVE_FRAMES - native_frames, java_ctx);


### PR DESCRIPTION
Native traces for allocations aren't very useful for the 99th centile user, and mostly record the profiler's mechanisms
<img width="937" alt="Screenshot 2022-12-02 at 11 54 17" src="https://user-images.githubusercontent.com/16439049/205287266-2e91e590-98df-4457-bef1-df830fe9f631.png">
