### PR TITLE
add API to set a thread's owner-pool's parallelism

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -25,11 +25,11 @@ const ContextSnapshot Contexts::get(int tid) {
     Context* page = _pages[pageIndex];
     if (page != NULL) {
         Context& context = page[tid % PAGE_SIZE];
-        if ((context.spanId ^ context.rootSpanId) == context.checksum) {
-            return {context.spanId, context.rootSpanId};
+        if ((context.spanId ^ context.rootSpanId) == context.checksum && context.spanId != 0) {
+            return {context.spanId, context.rootSpanId, context.parallelism};
         }
     }
-    return {0, 0};
+    return {0, 0, 1};
 }
 
 void Contexts::initialize(int pageIndex) {

--- a/src/context.h
+++ b/src/context.h
@@ -24,7 +24,8 @@ typedef struct {
     u64 spanId;
     u64 rootSpanId;
     u64 checksum;
-    u64 pad1;
+    u32 parallelism = 1;
+    u32 pad1;
     u64 pad2;
     u64 pad3;
     u64 pad4;
@@ -34,6 +35,7 @@ typedef struct {
 typedef struct {
     u64 spanId;
     u64 rootSpanId;
+    u32 parallelism;
 } ContextSnapshot;
 
 // must be kept in sync with PAGE_SIZE in AsyncProfiler.java

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1187,6 +1187,7 @@ class Recording {
         buf->putVar64(context.spanId);
         buf->putVar64(context.rootSpanId);
         buf->putVar64(event->_weight);
+        buf->putVar64(context.parallelism);
         buf->put8(start, buf->offset() - start);
     }
 

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -111,7 +111,8 @@ void JfrMetadata::initialize() {
                 << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                 << field("spanId", T_LONG, "Span ID")
                 << field("localRootSpanId", T_LONG, "Local Root Span ID")
-                << field("weight", T_LONG, "Sample weight"))
+                << field("weight", T_LONG, "Sample weight")
+                << field("parallelism", T_LONG, "Thread Pool Parallelism"))
 
             << (type("datadog.WallClockSamplingEpoch", T_WALLCLOCK_SAMPLE_EPOCH, "WallClock Sampling Epoch")
                 << category("Datadog", "Profiling")


### PR DESCRIPTION
A Java caller can call `AsyncProfiler.setPoolParallelism(int tid, int parallelism)` to indicate that a sampled thread belongs to a pool of `parallelism` peers, and this is recorded on wallclock samples with a default value of 1 (meaning there are known peers).