### PR TITLE
Cherry-pick unwinding improvements from upstream master

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -55,7 +55,7 @@ enum {
 };
 
 
-FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, -EMPTY_FRAME_SIZE};
+FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, INITIAL_PC_OFFSET};
 FrameDesc FrameDesc::default_frame = {0, DW_REG_FP | LINKED_FRAME_SIZE << 8, -LINKED_FRAME_SIZE, -LINKED_FRAME_SIZE + DW_STACK_SLOT};
 
 
@@ -136,12 +136,12 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
     u32 cfa_reg = DW_REG_SP;
     int cfa_off = EMPTY_FRAME_SIZE;
     int fp_off = DW_SAME_FP;
-    int pc_off = -EMPTY_FRAME_SIZE;
+    int pc_off = INITIAL_PC_OFFSET;
 
     u32 rem_cfa_reg = DW_REG_SP;
     int rem_cfa_off = EMPTY_FRAME_SIZE;
     int rem_fp_off = DW_SAME_FP;
-    int rem_pc_off = -EMPTY_FRAME_SIZE;
+    int rem_pc_off = INITIAL_PC_OFFSET;
 
     while (_ptr < end) {
         u8 op = get8();
@@ -270,6 +270,8 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
             case DW_CFA_restore:
                 if ((op & 0x3f) == DW_REG_FP) {
                     fp_off = DW_SAME_FP;
+                } else if ((op & 0x3f) == DW_REG_PC) {
+                    pc_off = INITIAL_PC_OFFSET;
                 }
                 break;
         }

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -15,6 +15,7 @@ const int DW_REG_INVALID = 255;  // denotes unsupported configuration
 
 const int DW_PC_OFFSET = 1;
 const int DW_SAME_FP = 0x80000000;
+const int DW_LINK_REGISTER = 0x80000000;
 const int DW_STACK_SLOT = sizeof(void*);
 
 
@@ -27,6 +28,7 @@ const int DW_REG_SP = 7;
 const int DW_REG_PC = 16;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int INITIAL_PC_OFFSET = -EMPTY_FRAME_SIZE;
 
 #elif defined(__i386__)
 
@@ -37,6 +39,7 @@ const int DW_REG_SP = 4;
 const int DW_REG_PC = 8;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int INITIAL_PC_OFFSET = -EMPTY_FRAME_SIZE;
 
 #elif defined(__aarch64__)
 
@@ -47,6 +50,7 @@ const int DW_REG_SP = 31;
 const int DW_REG_PC = 30;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+const int INITIAL_PC_OFFSET = DW_LINK_REGISTER;
 
 #else
 
@@ -57,6 +61,7 @@ const int DW_REG_SP = 1;
 const int DW_REG_PC = 2;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+const int INITIAL_PC_OFFSET = DW_LINK_REGISTER;
 
 #endif
 

--- a/src/stackFrame.h
+++ b/src/stackFrame.h
@@ -65,8 +65,13 @@ class StackFrame {
     }
 
     bool unwindStub(instruction_t* entry, const char* name, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
-    bool unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
     bool unwindAtomicStub(const void*& pc);
+
+    // TODO: this function will be removed once `vm` becomes the default stack walking mode
+    bool unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
+
+    bool unwindPrologue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
+    bool unwindEpilogue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
 
     void adjustSP(const void* entry, const void* pc, uintptr_t& sp);
 

--- a/src/stackFrame.h
+++ b/src/stackFrame.h
@@ -6,6 +6,7 @@
 #ifndef _STACKFRAME_H
 #define _STACKFRAME_H
 
+#include <stddef.h>
 #include <stdint.h>
 #include <ucontext.h>
 #include "arch.h"

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -101,6 +101,21 @@ bool StackFrame::unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintp
     return true;
 }
 
+bool StackFrame::unwindPrologue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    instruction_t* ip = (instruction_t*)pc;
+    instruction_t* entry = (instruction_t*)nm->entry();
+    if (ip <= entry) {
+        pc = link();
+        return true;
+    }
+    return false;
+}
+
+bool StackFrame::unwindEpilogue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
 bool StackFrame::unwindAtomicStub(const void*& pc) {
     // Not needed
     return false;

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -116,6 +116,27 @@ bool StackFrame::unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintp
     return false;
 }
 
+bool StackFrame::unwindPrologue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    instruction_t* ip = (instruction_t*)pc;
+    instruction_t* entry = (instruction_t*)nm->entry();
+    if (ip <= entry || *ip == 0x55) {  // push ebp
+        pc = *(uintptr_t*)sp;
+        sp += 4;
+        return true;
+    }
+    return false;
+}
+
+bool StackFrame::unwindEpilogue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    instruction_t* ip = (instruction_t*)pc;
+    if (*ip == 0xc3) {  // ret
+        pc = *(uintptr_t*)sp;
+        sp += 4;
+        return true;
+    }
+    return false;
+}
+
 bool StackFrame::unwindAtomicStub(const void*& pc) {
     // Not needed
     return false;

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -82,6 +82,16 @@ bool StackFrame::unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintp
     return false;
 }
 
+bool StackFrame::unwindPrologue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
+bool StackFrame::unwindEpilogue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
 bool StackFrame::unwindAtomicStub(const void*& pc) {
     // Not needed
     return false;

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -127,6 +127,16 @@ bool StackFrame::unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintp
     return true;
 }
 
+bool StackFrame::unwindPrologue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
+bool StackFrame::unwindEpilogue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
 bool StackFrame::unwindAtomicStub(const void*& pc) {
     // Not needed
     return false;

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -82,6 +82,16 @@ bool StackFrame::unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintp
     return false;
 }
 
+bool StackFrame::unwindPrologue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
+bool StackFrame::unwindEpilogue(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    // Not yet implemented
+    return false;
+}
+
 bool StackFrame::unwindAtomicStub(const void*& pc) {
     // Not needed
     return false;

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -269,6 +269,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                 fillFrame(frames[depth++], type, 0, nm->method()->id());
 
                 if (nm->isFrameCompleteAt(pc)) {
+                    if (depth == 1 && frame.unwindEpilogue(nm, (uintptr_t&)pc, sp, fp)) {
+                        continue;
+                    }
+
                     int scope_offset = nm->findScopeOffset(pc);
                     if (scope_offset > 0) {
                         depth--;
@@ -290,7 +294,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                     fp = ((uintptr_t*)sp)[-FRAME_PC_SLOT - 1];
                     pc = ((const void**)sp)[-FRAME_PC_SLOT];
                     continue;
-                } else if (frame.unwindCompiled(nm, (uintptr_t&)pc, sp, fp) && profiler->isAddressInCode(pc)) {
+                } else if (frame.unwindPrologue(nm, (uintptr_t&)pc, sp, fp)) {
                     continue;
                 }
 

--- a/test/native/libs/jninativestacks.c
+++ b/test/native/libs/jninativestacks.c
@@ -6,6 +6,18 @@
 #include <jni.h>
 #include <math.h>
 
+JNIEXPORT double largeInnerFrameFinal(int i) {
+    char frame[0x10000];
+    // Prevent from being optimized by compiler
+    (void)frame;
+
+    return sqrt(i) + pow(i, sqrt(i));
+}
+
+JNIEXPORT double largeInnerFrameIntermediate(int i) {
+    return largeInnerFrameFinal(i) + largeInnerFrameFinal(i + 1);
+}
+
 JNIEXPORT double doCpuTask() {
     int i = 0;
     double result = 0;
@@ -46,4 +58,12 @@ JNIEXPORT jdouble JNICALL Java_test_stackwalker_StackGenerator_deepFrame(JNIEnv*
 
 JNIEXPORT jdouble JNICALL Java_test_stackwalker_StackGenerator_leafFrame(JNIEnv* env, jclass cls) {
     return doCpuTask();
+}
+
+JNIEXPORT jdouble JNICALL Java_test_stackwalker_StackGenerator_largeInnerFrame(JNIEnv* env, jclass cls) {
+    double result = 0;
+    for (int i = 0; i < 100000000; i++) {
+        result += largeInnerFrameIntermediate(i);
+    }
+    return result;
 }

--- a/test/test/recovery/RecoveryTests.java
+++ b/test/test/recovery/RecoveryTests.java
@@ -24,6 +24,10 @@ public class RecoveryTests {
         out = p.profile("-d 3 -e cpu -o collapsed --safe-mode 2");
         Assert.isLess(out.ratio("StringBuilder.delete;"), 0.1);
         Assert.isGreater(out.ratio("unknown_Java"), 0.5);
+
+        out = p.profile("-d 2 -e cpu -i 1ms --cstack vm -o collapsed");
+        Assert.isGreater(out.ratio("StringBuilderTest.main;java/lang/StringBuilder.delete;"), 0.8);
+        Assert.isLess(out.ratio("unknown|break_compiled"), 0.002);
     }
 
     @Test(mainClass = StringBuilderTest.class, debugNonSafepoints = true, arch = {Arch.ARM64, Arch.ARM32})
@@ -34,6 +38,10 @@ public class RecoveryTests {
         out = p.profile("-d 3 -e cpu -o collapsed --safe-mode 2");
         Assert.isLess(out.ratio("StringBuilder.delete;"), 0.1);
         Assert.isGreater(out.ratio("unknown_Java"), 0.5);
+
+        out = p.profile("-d 2 -e cpu -i 1ms --cstack vm -o collapsed");
+        Assert.isGreater(out.ratio("StringBuilderTest.main;java/lang/StringBuilder.delete;"), 0.8);
+        Assert.isLess(out.ratio("unknown|break_compiled"), 0.002);
     }
 
     @Test(mainClass = Numbers.class, debugNonSafepoints = true)
@@ -44,6 +52,11 @@ public class RecoveryTests {
 
         out = p.profile("-d 3 -e cpu -o collapsed --safe-mode 31");
         Assert.isGreater(out.ratio("unknown_Java"), 0.05);
+
+        out = p.profile("-d 2 -e cpu -i 1ms --cstack vm -o collapsed");
+        Assert.isGreater(out.ratio("Numbers.main;test/recovery/Numbers.loop"), 0.8);
+        Assert.isGreater(out.ratio("Numbers.main;test/recovery/Numbers.loop;test/recovery/Numbers.avg"), 0.5);
+        Assert.isLess(out.ratio("unknown|break_compiled"), 0.002);
     }
 
     @Test(mainClass = Suppliers.class, debugNonSafepoints = true)
@@ -54,13 +67,24 @@ public class RecoveryTests {
         out = p.profile("-d 3 -e cpu -o collapsed");
         Assert.isGreater(out.ratio("itable stub"), 0.01);
         Assert.isGreater(out.ratio("Suppliers.loop"), 0.5);
+
+        out = p.profile("-d 2 -e cpu -i 1ms --cstack vm -o collapsed");
+        Assert.isGreater(out.ratio("Suppliers.main;test/recovery/Suppliers.loop"), 0.5);
+        Assert.isLess(out.ratio("unknown|break_compiled"), 0.002);
     }
 
-    @Test(mainClass = CodingIntrinsics.class, debugNonSafepoints = true, arch = {Arch.ARM64, Arch.X64}, inputs = "")
-    @Test(mainClass = CodingIntrinsics.class, debugNonSafepoints = true, arch = {Arch.ARM64, Arch.X64}, inputs = "--cstack vm", nameSuffix = "VM")
+    @Test(mainClass = CodingIntrinsics.class, debugNonSafepoints = true, arch = {Arch.ARM64, Arch.X64})
     public void intrinsics(TestProcess p) throws Exception {
-        Output out = p.profile("-d 3 -e cpu -i 1ms -o collapsed " + p.inputs()[0]);
+        Output out = p.profile("-d 3 -e cpu -i 1ms -o collapsed");
         Assert.isLess(out.ratio("^\\[unknown"), 0.02, "No more than 2% of unknown frames");
         Assert.isLess(out.ratio("^[^ ;]+(;[^ ;]+)? "), 0.02, "No more than 2% of short stacks");
+    }
+
+    @Test(mainClass = CodingIntrinsics.class, debugNonSafepoints = true, arch = {Arch.ARM64, Arch.X64})
+    public void intrinsicsVM(TestProcess p) throws Exception {
+        // cstack=vm should yield less unknown frames than AsyncGetCallTrace
+        Output out = p.profile("-d 3 -e cpu -i 1ms -o collapsed --cstack vm");
+        Assert.isLess(out.ratio("^\\[unknown"), 0.01, "No more than 1% of unknown frames");
+        Assert.isLess(out.ratio("^[^ ;]+(;[^ ;]+)? "), 0.01, "No more than 1% of short stacks");
     }
 }

--- a/test/test/stackwalker/StackGenerator.java
+++ b/test/test/stackwalker/StackGenerator.java
@@ -13,6 +13,8 @@ public class StackGenerator {
 
     public static native double leafFrame();
 
+    public static native double largeInnerFrame();
+
     static {
         System.loadLibrary("jninativestacks");
     }
@@ -29,6 +31,8 @@ public class StackGenerator {
             deepFrame();
         } else if (args[0].equals("leafFrame")) {
             leafFrame();
+        } else if (args[0].equals("largeInnerFrame")) {
+            largeInnerFrame();
         } else {
             System.err.println("Unknown test: " + args[0]);
             System.exit(1);

--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -84,4 +84,14 @@ public class StackwalkerTests {
                 "Java_test_stackwalker_StackGenerator_leafFrame;" +
                 "doCpuTask");
     }
+
+    @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "largeInnerFrame",
+            agentArgs = "start,event=cpu,cstack=vm,file=%f.jfr")
+    public void largeInnerFrameVM(TestProcess p) throws Exception {
+        p.waitForExit();
+        assert p.exitCode() == 0;
+
+        Output output = Output.convertJfrToCollapsed(p.getFilePath("%f"));
+        assert !output.contains("Java_test_stackwalker_StackGenerator_largeInnerFrame;unknown;largeInnerFrameFinal");
+    }
 }


### PR DESCRIPTION
### Description

This PR cherry-picks two important unwinding improvements from the upstream master branch to dd/master:

1. **Unwind top frame on ARM using link register** (#1463) - commit 6b81f6d
2. **Special handling of prologue and epilogue of compiled methods with cstack=vm** (#1449) - commit dd24673

These commits improve stack unwinding reliability, particularly for ARM architectures and compiled method boundaries when using `cstack=vm` mode.

### Related issues

Original PRs:
- #1463: Unwind top frame on ARM using link register  
- #1449: Special handling of prologue and epilogue of compiled methods with cstack=vm

### Motivation and context

These changes are critical for improving stack trace accuracy and reducing unknown frames in profiling output. The commits address:

- Better handling of stack unwinding on ARM platforms using link registers
- Improved prologue/epilogue detection for compiled methods
- Enhanced DWARF-based stack walking with proper PC offset handling
- Additional test coverage for large frame scenarios

Cherry-picking these upstream improvements ensures dd/master benefits from the latest unwinding enhancements.

### How has this been tested?

- All existing tests pass (recovery tests, stack walker tests)
- New test cases added for large inner frame scenarios
- Validated on ARM64 and x64 architectures
- Verified reduced unknown frame ratios in test assertions

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

🤖 Generated with [Claude Code](https://claude.ai/code)

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0