### PR TITLE
Skip missing libc/pthread symbols & use java thread anchor as a fallback.

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -396,44 +396,42 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             if (detail < VM_EXPERT) {
                 // These workarounds will minimize the number of unknown frames for 'vm'
                 // We want to keep the 'raw' data in 'vmx', though
-                if (symbol == NULL && Symbols::isLibcOrPthreadAddress((uintptr_t)pc)) {
-                    // We might not have the libc symbols available
-                    // The unwinding is also not super reliable; best to jump out if this is not the leaf
-                    fillFrame(frames[depth++], BCI_NATIVE_FRAME, "[libc/pthread]");
-                    break;
-                } else if (symbol == NULL) {
-                    const char* prev_symbol = prev_native_pc != NULL ? profiler->findNativeMethod(prev_native_pc) : NULL;
-                    if (prev_symbol != NULL && strstr(prev_symbol, "thread_start")) {
-                        // Unwinding from Rust 'thread_start' but not having enough info to do it correctly
-                        // Rather, just assume that this is the root frame
-                        break;
-                    }
+                if (symbol == NULL) {
                     // let's see if we have the thread java frame anchor and if yes, let's use it
                     if (anchor) {
                         uintptr_t prev_sp = sp;
                         sp = anchor->lastJavaSP();
                         fp = anchor->lastJavaFP();
                         pc = anchor->lastJavaPC();
-                        if (sp == 0 || pc == NULL) {
-                            // End of Java stack
-                            break;
+                        if (sp != 0 && pc != NULL) {
+                            // already used the anchor; disable it
+                            anchor = NULL;
+                            if (sp < prev_sp || sp >= bottom || !aligned(sp)) {
+                                fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
+                                break;
+                            }
+                            // we restored from Java frame; clean the prev_native_pc
+                            prev_native_pc = NULL;
+                            if (depth > 0) {
+                                fillFrame(frames[depth++], BCI_ERROR, "[skipped frames]");
+                            }
+                            continue;
                         }
-                        if (sp < prev_sp || sp >= bottom || !aligned(sp)) {
-                            fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
-                            break;
-                        }
-                        if (depth > 0) {
-                            fillFrame(frames[depth++], BCI_ERROR, "[skipped frames]");
-                        }
-                        // already used the anchor; disable it
-                        anchor = NULL;
-                        // we restored from Java frame; clean the prev_native_pc
-                        prev_native_pc = NULL;
-                        continue;
-                    } else {
-                        fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
+                    }
+                    const char* prev_symbol = prev_native_pc != NULL ? profiler->findNativeMethod(prev_native_pc) : NULL;
+                    if (prev_symbol != NULL && strstr(prev_symbol, "thread_start")) {
+                        // Unwinding from Rust 'thread_start' but not having enough info to do it correctly
+                        // Rather, just assume that this is the root frame
                         break;
                     }
+                    if (Symbols::isLibcOrPthreadAddress((uintptr_t)pc)) {
+                        // We might not have the libc symbols available
+                        // The unwinding is also not super reliable; best to jump out if this is not the leaf
+                        fillFrame(frames[depth++], BCI_NATIVE_FRAME, "[libc/pthread]");
+                        break;
+                    }
+                    fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
+                    break;
                 }
             }
             fillFrame(frames[depth++], BCI_NATIVE_FRAME, symbol);

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -396,9 +396,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             if (detail < VM_EXPERT) {
                 // These workarounds will minimize the number of unknown frames for 'vm'
                 // We want to keep the 'raw' data in 'vmx', though
-                if (symbol == NULL && depth > 0 && Symbols::isLibcOrPthreadAddress((uintptr_t)pc)) {
+                if (symbol == NULL && Symbols::isLibcOrPthreadAddress((uintptr_t)pc)) {
                     // We might not have the libc symbols available
                     // The unwinding is also not super reliable; best to jump out if this is not the leaf
+                    fillFrame(frames[depth++], BCI_NATIVE_FRAME, "[libc/pthread]");
                     break;
                 } else if (symbol == NULL) {
                     const char* prev_symbol = prev_native_pc != NULL ? profiler->findNativeMethod(prev_native_pc) : NULL;

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -9,6 +9,7 @@
 #include "profiler.h"
 #include "safeAccess.h"
 #include "stackFrame.h"
+#include "symbols.h"
 #include "vmStructs.h"
 
 
@@ -246,7 +247,9 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
     // Should be preserved across setjmp/longjmp
     volatile int depth = 0;
 
+    JavaFrameAnchor* anchor = NULL;
     if (vm_thread != NULL) {
+        anchor = vm_thread->anchor();
         vm_thread->exception() = &crash_protection_ctx;
         if (setjmp(crash_protection_ctx) != 0) {
             vm_thread->exception() = saved_exception;
@@ -257,9 +260,12 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
         }
     }
 
+    const void* prev_native_pc = NULL;
+
     // Walk until the bottom of the stack or until the first Java frame
     while (depth < max_depth) {
         if (CodeHeap::contains(pc)) {
+            prev_native_pc = NULL; // we are in JVM code, no previous 'native' PC
             NMethod* nm = CodeHeap::findNMethod(pc);
             if (nm == NULL) {
                 fillFrame(frames[depth++], BCI_ERROR, "unknown_nmethod");
@@ -386,7 +392,50 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                 }
             }
         } else {
-            fillFrame(frames[depth++], BCI_NATIVE_FRAME, profiler->findNativeMethod(pc));
+            const char* symbol = profiler->findNativeMethod(pc);
+            if (detail < VM_EXPERT) {
+                // These workarounds will minimize the number of unknown frames for 'vm'
+                // We want to keep the 'raw' data in 'vmx', though
+                if (symbol == NULL && depth > 0 && Symbols::isLibcOrPthreadAddress((uintptr_t)pc)) {
+                    // We might not have the libc symbols available
+                    // The unwinding is also not super reliable; best to jump out if this is not the leaf
+                    break;
+                } else if (symbol == NULL) {
+                    const char* prev_symbol = prev_native_pc != NULL ? profiler->findNativeMethod(prev_native_pc) : NULL;
+                    if (prev_symbol != NULL && strstr(prev_symbol, "thread_start")) {
+                        // Unwinding from Rust 'thread_start' but not having enough info to do it correctly
+                        // Rather, just assume that this is the root frame
+                        break;
+                    }
+                    // let's see if we have the thread java frame anchor and if yes, let's use it
+                    if (anchor) {
+                        uintptr_t prev_sp = sp;
+                        sp = anchor->lastJavaSP();
+                        fp = anchor->lastJavaFP();
+                        pc = anchor->lastJavaPC();
+                        if (sp == 0 || pc == NULL) {
+                            // End of Java stack
+                            break;
+                        }
+                        if (sp < prev_sp || sp >= bottom || !aligned(sp)) {
+                            fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
+                            break;
+                        }
+                        if (depth > 0) {
+                            fillFrame(frames[depth++], BCI_ERROR, "[skipped frames]");
+                        }
+                        // already used the anchor; disable it
+                        anchor = NULL;
+                        // we restored from Java frame; clean the prev_native_pc
+                        prev_native_pc = NULL;
+                        continue;
+                    } else {
+                        fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
+                        break;
+                    }
+                }
+            }
+            fillFrame(frames[depth++], BCI_NATIVE_FRAME, symbol);
         }
 
         uintptr_t prev_sp = sp;
@@ -415,7 +464,8 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             break;
         }
 
-        const void* prev_pc = pc; 
+        // store the previous pc before unwinding
+        prev_native_pc = pc;
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
@@ -440,7 +490,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             }
         }
 
-        if (inDeadZone(pc) || (pc == prev_pc && sp == prev_sp)) {
+        if (inDeadZone(pc) || (pc == prev_native_pc && sp == prev_sp)) {
             break;
         }
     }

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -9,6 +9,8 @@
 #include "codeCache.h"
 #include "mutex.h"
 
+#include <stdint.h>
+
 
 class Symbols {
   private:
@@ -23,6 +25,8 @@ class Symbols {
     static bool haveKernelSymbols() {
         return _have_kernel_symbols;
     }
+    // Fast range check: does this PC lie in libc or libpthread?
+    static bool isLibcOrPthreadAddress(uintptr_t pc);
 };
 
 class UnloadProtection {

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -180,7 +180,6 @@ static bool pc_in_range(uintptr_t pc, const Range* r) {
 #include <poll.h>
 #include "vmEntry.h"
 
-
 // Workaround for JDK-8312065 on JDK 8:
 // replace poll() implementation with ppoll() which is restartable
 static int poll_hook(struct pollfd* fds, nfds_t nfds, int timeout) {
@@ -1019,7 +1018,6 @@ UnloadProtection::~UnloadProtection() {
 }
 
 bool Symbols::isLibcOrPthreadAddress(uintptr_t pc) {
-    // Caller should already normalize boundary PCs (pc-1) if using return addresses.
     init_lib_ranges_once();
     // Fast, allocation-free integer checks — no strings involved.
     if (pc_in_range(pc, &g_libc)) return true;

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <link.h>
 #include <linux/limits.h>
+#include <pthread.h>
 #include <sys/auxv.h>
 #include "symbols.h"
 #include "dwarf.h"
@@ -27,11 +28,158 @@
 #include "log.h"
 #include "os.h"
 
+// Simple address range
+struct Range {
+    uintptr_t start;
+    uintptr_t end;
+};
+
+static bool range_valid(const Range* r) {
+    return r->start && r->end && r->end > r->start;
+}
+
+static Range g_libc = {0, 0};
+static Range g_libpthread = {0, 0};
+static bool g_lib_ranges_inited = false;
+
+// Unified dl_iterate_phdr callback context
+struct UnifiedCtx {
+    void* fbase;           // For range_for_fbase functionality
+    Range* out;            // For range_for_fbase functionality
+    const void** main_phdr; // For getMainPhdr functionality
+    void* libc_fbase;      // For init_lib_ranges_once functionality
+    void* pthread_fbase;   // For init_lib_ranges_once functionality
+    Range* libc_range;     // For init_lib_ranges_once functionality
+    Range* pthread_range;  // For init_lib_ranges_once functionality
+};
+
+// Unified callback for both range computation and main phdr collection
+static int unified_phdr_cb(dl_phdr_info* info, size_t, void* data) {
+    UnifiedCtx* ctx = (UnifiedCtx*)data;
+
+    // Main executable's program header (first entry)
+    if (ctx->main_phdr != NULL && *ctx->main_phdr == NULL) {
+        *ctx->main_phdr = info->dlpi_phdr;
+    }
+
+    // Range computation for specific fbase (range_for_fbase functionality)
+    if (ctx->fbase != NULL && (void*)info->dlpi_addr == ctx->fbase) {
+        uintptr_t minv = (uintptr_t)-1;
+        uintptr_t maxv = 0;
+        for (int i = 0; i < info->dlpi_phnum; i++) {
+            const ElfW(Phdr)* ph = &info->dlpi_phdr[i];
+            if (ph->p_type != PT_LOAD) continue;
+            uintptr_t vaddr = (uintptr_t)info->dlpi_addr + ph->p_vaddr;
+            uintptr_t vend = vaddr + ph->p_memsz;
+            if (vaddr < minv) minv = vaddr;
+            if (vend > maxv) maxv = vend;
+        }
+        if (minv != (uintptr_t)-1 && maxv > minv) {
+            ctx->out->start = minv;
+            ctx->out->end = maxv;
+        }
+    }
+
+    // Library range computation (init_lib_ranges_once functionality)
+    if (ctx->libc_fbase != NULL && (void*)info->dlpi_addr == ctx->libc_fbase) {
+        uintptr_t minv = (uintptr_t)-1;
+        uintptr_t maxv = 0;
+        for (int i = 0; i < info->dlpi_phnum; i++) {
+            const ElfW(Phdr)* ph = &info->dlpi_phdr[i];
+            if (ph->p_type != PT_LOAD) continue;
+            uintptr_t vaddr = (uintptr_t)info->dlpi_addr + ph->p_vaddr;
+            uintptr_t vend = vaddr + ph->p_memsz;
+            if (vaddr < minv) minv = vaddr;
+            if (vend > maxv) maxv = vend;
+        }
+        if (minv != (uintptr_t)-1 && maxv > minv) {
+            ctx->libc_range->start = minv;
+            ctx->libc_range->end = maxv;
+        }
+    }
+
+    if (ctx->pthread_fbase != NULL && (void*)info->dlpi_addr == ctx->pthread_fbase) {
+        uintptr_t minv = (uintptr_t)-1;
+        uintptr_t maxv = 0;
+        for (int i = 0; i < info->dlpi_phnum; i++) {
+            const ElfW(Phdr)* ph = &info->dlpi_phdr[i];
+            if (ph->p_type != PT_LOAD) continue;
+            uintptr_t vaddr = (uintptr_t)info->dlpi_addr + ph->p_vaddr;
+            uintptr_t vend = vaddr + ph->p_memsz;
+            if (vaddr < minv) minv = vaddr;
+            if (vend > maxv) maxv = vend;
+        }
+        if (minv != (uintptr_t)-1 && maxv > minv) {
+            ctx->pthread_range->start = minv;
+            ctx->pthread_range->end = maxv;
+        }
+    }
+
+    return 0; // continue iteration
+}
+
+// Main program header - initialized lazily
+static const void* _main_phdr = NULL;
+static pthread_once_t _main_phdr_once = PTHREAD_ONCE_INIT;
+static const char* _ld_base = (const char*)getauxval(AT_BASE);
+
+// Initialize main phdr once
+static void init_main_phdr_once() {
+    UnifiedCtx ctx = {NULL, NULL, &_main_phdr, NULL, NULL, NULL, NULL};
+    dl_iterate_phdr(&unified_phdr_cb, &ctx);
+}
+
+// Ensure main phdr is initialized
+static void ensure_main_phdr_initialized() {
+    pthread_once(&_main_phdr_once, init_main_phdr_once);
+}
+
+static Range range_for_fbase(void* fbase) {
+    Range r = {0, 0};
+    if (!fbase) return r;
+    UnifiedCtx ctx = {fbase, &r, NULL, NULL, NULL, NULL, NULL};
+    dl_iterate_phdr(&unified_phdr_cb, &ctx);
+    return r;
+}
+
+static void init_lib_ranges_once() {
+    if (g_lib_ranges_inited) return;
+    g_lib_ranges_inited = true;
+
+    // libc anchor: prefer gnu_get_libc_version if present; fallback to strlen
+    void* libc_sym = dlsym(RTLD_DEFAULT, "gnu_get_libc_version");
+    if (!libc_sym) libc_sym = (void*)&strlen;
+
+    Dl_info di = {0};
+    void* libc_fbase = NULL;
+    if (dladdr(libc_sym, &di) && di.dli_fbase) {
+        libc_fbase = di.dli_fbase;
+    }
+
+    // pthread anchor: pthread_create (on glibc >= 2.34 this lives in libc)
+    Dl_info di2 = {0};
+    void* pthread_fbase = NULL;
+    if (dladdr((void*)&pthread_create, &di2) && di2.dli_fbase) {
+        pthread_fbase = di2.dli_fbase;
+    }
+
+    // Use unified dl_iterate_phdr call to get all information at once
+    UnifiedCtx ctx = {NULL, NULL, &_main_phdr, libc_fbase, pthread_fbase, &g_libc, &g_libpthread};
+    dl_iterate_phdr(&unified_phdr_cb, &ctx);
+
+    // If pthread couldn't be resolved separately, treat it as libc
+    if (!range_valid(&g_libpthread)) g_libpthread = g_libc;
+}
+
+static bool pc_in_range(uintptr_t pc, const Range* r) {
+    return range_valid(r) && pc >= r->start && pc < r->end;
+}
 
 #ifdef __x86_64__
 
 #include <poll.h>
 #include "vmEntry.h"
+
 
 // Workaround for JDK-8312065 on JDK 8:
 // replace poll() implementation with ppoll() which is restartable
@@ -67,19 +215,9 @@ static void applyPatch(CodeCache* cc) {}
 
 #endif
 
-static const void* getMainPhdr() {
-    void* main_phdr = NULL;
-    dl_iterate_phdr([](struct dl_phdr_info* info, size_t size, void* data) {
-        *(const void**)data = info->dlpi_phdr;
-        return 1;
-    }, &main_phdr);
-    return main_phdr;
-}
-
-static const void* _main_phdr = getMainPhdr();
-static const char* _ld_base = (const char*)getauxval(AT_BASE);
 
 static bool isMainExecutable(const char* image_base, const void* map_end) {
+    ensure_main_phdr_initialized();
     return _main_phdr != NULL && _main_phdr >= image_base && _main_phdr < map_end;
 }
 
@@ -879,5 +1017,15 @@ UnloadProtection::~UnloadProtection() {
         dlclose(_lib_handle);
     }
 }
+
+bool Symbols::isLibcOrPthreadAddress(uintptr_t pc) {
+    // Caller should already normalize boundary PCs (pc-1) if using return addresses.
+    init_lib_ranges_once();
+    // Fast, allocation-free integer checks — no strings involved.
+    if (pc_in_range(pc, &g_libc)) return true;
+    if (pc_in_range(pc, &g_libpthread)) return true;
+    return false;
+}
+
 
 #endif // __linux__

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -54,7 +54,7 @@ struct UnifiedCtx {
 };
 
 // Unified callback for both range computation and main phdr collection
-static int unified_phdr_cb(dl_phdr_info* info, size_t, void* data) {
+static int unified_phdr_cb(dl_phdr_info* info, size_t /*unused*/, void* data) {
     UnifiedCtx* ctx = (UnifiedCtx*)data;
 
     // Main executable's program header (first entry)

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -183,4 +183,8 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     }
 }
 
+bool Symbols::isLibcOrPthreadAddress(uintptr_t pc) {
+    return false;
+}
+
 #endif // __APPLE__


### PR DESCRIPTION
### Description
This is a small heuristic providing fallback in cases where we see 'unknown' frames.
It removes unknowns for:
- non-leaf libc/pthread functions without exported symbols
- various unwinding failures in JVM stubs and veneers when we, in fact, have the Java Frame Anchor available

### Motivation and context
Minimize the number of 'unknown' frames. Provide the best experience for intermediate users (the 'experts' using 'vmx' stackwalker will still see those unknowns)

### How has this been tested?
All current tests are passing. No new extra tests were added


#### JIRA
[PROF-12677]


---
Plugging this to Datadog Java profiler library and running the unwinding validator suite I am getting these amazing results :)

## 🔍 Unwinding Quality Report

**Generated**: 2025-09-19T15:38:40.183760567Z  
**Platform**: Linux amd64  
**Java**: 21.0.8

### 📊 Summary

🟢 **EXCELLENT**: All unwinding scenarios performing well  
**Results**: 🟢 13 excellent   
**Error Rate**: 0.000% (0 errors / 5401 samples)  

### 🎯 Scenario Results

| Scenario | Status | Error Rate | Samples | Native % | Duration |
|----------|--------|------------|---------|----------|---------|
| C2CompilationTriggers | 🟢 | 0.00% | 73 | 47.9% | 0.6s |
| OSRScenarios | 🟢 | 0.00% | 148 | 79.1% | 0.4s |
| ConcurrentC2Compilation | 🟢 | 0.00% | 702 | 19.8% | 0.5s |
| C2DeoptScenarios | 🟢 | 0.00% | 1,205 | 57.5% | 1.1s |
| ExtendedJNIScenarios | 🟢 | 0.00% | 351 | 92.3% | 0.4s |
| MultipleStressRounds | 🟢 | 0.00% | 631 | 54.8% | 0.5s |
| ExtendedPLTScenarios | 🟢 | 0.00% | 223 | 87.4% | 0.3s |
| ActivePLTResolution | 🟢 | 0.00% | 502 | 68.9% | 0.4s |
| ConcurrentCompilationS... | 🟢 | 0.00% | 1,236 | 32.4% | 0.8s |
| VeneerHeavyScenarios | 🟢 | 0.00% | 15 | 93.3% | 0.3s |
| RapidTierTransitions | 🟢 | 0.00% | 33 | 69.7% | 0.3s |
| DynamicLibraryOps | 🟢 | 0.00% | 6 | 33.3% | 0.3s |
| StackBoundaryStress | 🟢 | 0.00% | 276 | 40.6% | 0.4s |

---

**⚡ Performance**: 6.3s total execution time  
**🐌 Slowest test**: C2DeoptScenarios (1.1s)  
**📈 Coverage**: 5,401 total samples, 2,746 native (50.8%), 67 stub (1.2%)  


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0


[PROF-12677]: https://datadoghq.atlassian.net/browse/PROF-12677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ