### PR TITLE
Fix lazy library ranges init - it may cause allocation from signal handler

### DIFF
--- a/src/symbols.h
+++ b/src/symbols.h
@@ -19,6 +19,7 @@ class Symbols {
     static bool _libs_limit_reported;
 
   public:
+    static void initLibraryRanges();
     static void parseKernelSymbols(CodeCache* cc);
     static void parseLibraries(CodeCacheArray* array, bool kernel_symbols);
 

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -1025,9 +1025,13 @@ UnloadProtection::~UnloadProtection() {
     }
 }
 
-bool Symbols::isLibcOrPthreadAddress(uintptr_t pc) {
+void Symbols::initLibraryRanges() {
     init_lib_ranges_once();
+}
+
+bool Symbols::isLibcOrPthreadAddress(uintptr_t pc) {
     // Fast, allocation-free integer checks — no strings involved.
+    // initLibraryRanges() must have been called during profiler startup.
     if (pc_in_range(pc, &g_libc)) return true;
     if (pc_in_range(pc, &g_libpthread)) return true;
     return false;

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -183,6 +183,10 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     }
 }
 
+void Symbols::initLibraryRanges() {
+    // No initialization needed on macOS
+}
+
 bool Symbols::isLibcOrPthreadAddress(uintptr_t pc) {
     return false;
 }

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -18,6 +18,7 @@
 #include "instrument.h"
 #include "lockTracer.h"
 #include "log.h"
+#include "symbols.h"
 #include "vmStructs.h"
 
 
@@ -140,6 +141,9 @@ bool VM::init(JavaVM* vm, bool attach) {
     if (_vm->GetEnv((void**)&_jvmti, JVMTI_VERSION_1_0) != 0) {
         return false;
     }
+
+    // Initialize library ranges before any signal handlers can be installed
+    Symbols::initLibraryRanges();
 
     bool is_hotspot = false;
     bool is_zero_vm = false;


### PR DESCRIPTION
The lazy library range initialization is wrong because it can be triggered from a signal handler.
We need a greedy one at the startup.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
